### PR TITLE
Feature: Add terminal splash

### DIFF
--- a/addons/webpack-base/common/package/devDependencies.js
+++ b/addons/webpack-base/common/package/devDependencies.js
@@ -1,5 +1,6 @@
 module.exports = {
   "@testing-library/react": "latest",
+  chalk: "4.1.2",
   "clean-webpack-plugin": "latest",
   "copy-webpack-plugin": "latest",
   "css-loader": "latest",

--- a/addons/webpack-base/common/template/config/plugins/terminal-splash-plugin.js.template
+++ b/addons/webpack-base/common/template/config/plugins/terminal-splash-plugin.js.template
@@ -1,0 +1,34 @@
+const chalk = require('chalk');
+
+const clearConsole = () =>
+  process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
+
+const successCompilation = (url) => {
+  clearConsole();
+  console.log('');
+  console.log(chalk.bgHex('#008c61')(' <%= projectName%> '));
+  console.log('');
+  console.log(chalk.bold(' 🚀  App is available locally:') + ' ' + chalk.underline(url));
+  console.log('');
+};
+
+const compiling = () => {
+  clearConsole();
+  console.log('');
+  console.log(' 🧪  Compiling...');
+  console.log('');
+};
+
+class TerminalSplashPlugin {
+  constructor(props) {
+    this.options = props.options;
+  }
+  apply(compiler) {
+    compiler.hooks.done.tap('done', () => {
+      successCompilation(this.options.url);
+    });
+    compiler.hooks.invalid.tap('invalid', compiling);
+  }
+}
+
+module.exports = TerminalSplashPlugin;

--- a/addons/webpack-base/common/template/config/webpack.development.js.template
+++ b/addons/webpack-base/common/template/config/webpack.development.js.template
@@ -1,4 +1,5 @@
 const paths = require('./paths');
+const TerminalSplashPlugin = require('./plugins/terminal-splash-plugin');
 
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -23,6 +24,13 @@ const config = {
     host: HOST,
     port: DEFAULT_PORT,
   },
+  plugins: [
+    new TerminalSplashPlugin({
+      options: {
+        url: URL_BASE,
+      },
+    }),
+  ],
 };
 
 module.exports = config;


### PR DESCRIPTION
When we are developing in a local environment and run `npm start` we see the default output of webpack. The idea of this PR is to show a cleaner message and indicate when it finished "compiling" and a loading message of "compiling".