### PR TITLE
fix: modernize Redux extensions to RTK, re-enable type-check in CI

### DIFF
--- a/.github/workflows/test-combinations.yml
+++ b/.github/workflows/test-combinations.yml
@@ -122,7 +122,7 @@ jobs:
           npm run format --if-present
           npm run lint:fix --if-present
           npm run lint --if-present
-          npm run type-check --if-present || true
+          npm run type-check --if-present
           SKIP_ENV_VALIDATION=true npm run build --if-present
 
           tree -I 'node_modules|dist|.git'

--- a/extensions/react-ionic/.npmrc
+++ b/extensions/react-ionic/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/extensions/react-redux-saga/[src]/reducers/index.ts
+++ b/extensions/react-redux-saga/[src]/reducers/index.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from 'redux';
+import { combineReducers } from '@reduxjs/toolkit';
 
-export default () =>
-  combineReducers({
-    // Add your custom reducers here
-  });
+const rootReducer = combineReducers({
+  // Add your slice reducers here
+});
+
+export default rootReducer;

--- a/extensions/react-redux-saga/[src]/store.ts.template
+++ b/extensions/react-redux-saga/[src]/store.ts.template
@@ -1,49 +1,47 @@
 import createSagaMiddleware from 'redux-saga';
 import { createLogger } from 'redux-logger';
 import { persistStore, persistReducer } from 'redux-persist';
-import { applyMiddleware, createStore, compose } from 'redux';
-
-import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
+import { configureStore } from '@reduxjs/toolkit';
 import storage from 'redux-persist/lib/storage';
 
-import { StoreType } from '<%= projectImportPath %>types/store';
-import reducers from '<%= projectImportPath %>reducers';
+import rootReducer from '<%= projectImportPath %>reducers';
 import rootSaga from '<%= projectImportPath %>sagas';
 
 const persistConfig = {
   key: 'root',
   storage,
   blacklist: [],
-  stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
 };
 
-const packages = [];
-const enhancers = [];
-
-// Saga
 const sagaMiddleware = createSagaMiddleware();
 
-// Push middleware that you need for both development and production
-packages.push(sagaMiddleware);
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
-if (import.meta.env.DEV) {
-  // Push the middleware that are specific for development
-  packages.push(createLogger());
-  if (window.__REDUX_DEVTOOLS_EXTENSION__) {
-    enhancers.push(window.__REDUX_DEVTOOLS_EXTENSION__());
-  }
-}
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) => {
+    const middlewares = getDefaultMiddleware({
+      thunk: false,
+      serializableCheck: {
+        ignoredActions: ['persist/PERSIST', 'persist/REHYDRATE'],
+      },
+    }).concat(sagaMiddleware);
 
-const middleware = applyMiddleware(...packages);
+    if (import.meta.env.DEV) {
+      middlewares.concat(createLogger() as any);
+    }
 
-export const store = createStore(
-  persistReducer<StoreType>(persistConfig, reducers()),
-  compose(middleware, ...enhancers),
-);
+    return middlewares;
+  },
+  devTools: import.meta.env.DEV,
+});
 
 sagaMiddleware.run(rootSaga);
 
 export const persistor = persistStore(store);
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
 
 export default {
   store,

--- a/extensions/react-redux-saga/[src]/types/global.d.ts
+++ b/extensions/react-redux-saga/[src]/types/global.d.ts
@@ -1,4 +1,0 @@
-declare interface Window {
-  __REDUX_DEVTOOLS_EXTENSION__: any;
-  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any;
-}

--- a/extensions/react-redux-saga/[src]/types/store.ts
+++ b/extensions/react-redux-saga/[src]/types/store.ts
@@ -1,3 +1,4 @@
-import { CombinedState } from "redux";
+import type { store } from '<%= projectImportPath %>store';
 
-export type StoreType = CombinedState<object>
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/extensions/react-redux-saga/package.json
+++ b/extensions/react-redux-saga/package.json
@@ -1,13 +1,12 @@
 {
   "dependencies": {
-    "react-redux": "^9.0.2",
-    "redux": "^5.0.1",
+    "@reduxjs/toolkit": "^2.5.0",
+    "react-redux": "^9.2.0",
     "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.3.0"
   },
   "devDependencies": {
-    "@types/redux-logger": "^3.0.13",
-    "@types/react-redux": "^7.1.34"
+    "@types/redux-logger": "^3.0.13"
   }
 }

--- a/extensions/react-redux-thunk/README.md
+++ b/extensions/react-redux-thunk/README.md
@@ -1,64 +1,75 @@
-# React Redux with Thunk Extension
+# React Redux with Redux Toolkit Extension
 
-This extension adds Redux with Redux Thunk to your React application for predictable state management with support for asynchronous actions.
+This extension adds [Redux Toolkit (RTK)](https://redux-toolkit.js.org/) with React Redux bindings to your React application for predictable state management.
 
 ## Features
 
-- Integration with Redux and Redux Thunk
-- Predictable state management
-- Async action support
-- Time-travel debugging
-- Performance optimization
-- Development workflow helpers
+- Redux Toolkit (`configureStore`) with built-in thunk middleware
+- Redux Persist for state persistence across sessions
+- Redux Logger for development debugging
+- Redux DevTools integration (automatic in development)
+- TypeScript support with typed `RootState` and `AppDispatch`
 
 ## Usage
 
-Redux with Thunk is automatically configured when this extension is added to your project. The extension includes:
+Redux Toolkit is automatically configured when this extension is added to your project. The extension includes:
 
-- Redux store configuration
-- Redux Thunk middleware setup
-- Action creators and reducers
-- React-Redux bindings
-- Redux DevTools integration
-- TypeScript support
+- Pre-configured store with `configureStore`
+- Redux Persist setup with localStorage
+- Redux Logger (development only)
+- Typed hooks and store exports
+- Root reducer with `combineReducers`
 
 ## Key Concepts
 
 - **Store**: Single source of truth for application state
-- **Actions**: Plain objects describing what happened
-- **Reducers**: Pure functions that specify how state changes
-- **Thunks**: Functions that can dispatch actions asynchronously
+- **Slices**: Bundles of reducers + actions created with `createSlice`
+- **Thunks**: Async logic via `createAsyncThunk` (built into RTK)
+- **Selectors**: Functions to extract data from the store
 
 ## Basic Usage
 
 ```tsx
 import { useSelector, useDispatch } from 'react-redux';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import type { RootState, AppDispatch } from './store';
 
-// Thunk action creator
-const fetchUser = (userId) => async (dispatch) => {
-  dispatch({ type: 'FETCH_USER_START' });
-  try {
-    const user = await api.getUser(userId);
-    dispatch({ type: 'FETCH_USER_SUCCESS', payload: user });
-  } catch (error) {
-    dispatch({ type: 'FETCH_USER_ERROR', payload: error.message });
-  }
-};
+// Create an async thunk
+const fetchUser = createAsyncThunk('user/fetch', async (userId: string) => {
+  const response = await api.getUser(userId);
+  return response.data;
+});
 
-function UserProfile({ userId }) {
-  const user = useSelector(state => state.user);
-  const dispatch = useDispatch();
+// Create a slice
+const userSlice = createSlice({
+  name: 'user',
+  initialState: { data: null, loading: false },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchUser.pending, (state) => { state.loading = true; })
+      .addCase(fetchUser.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      });
+  },
+});
+
+// Use in components
+function UserProfile({ userId }: { userId: string }) {
+  const user = useSelector((state: RootState) => state.user);
+  const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
     dispatch(fetchUser(userId));
-  }, [userId]);
+  }, [userId, dispatch]);
 
-  return <div>{user.name}</div>;
+  return <div>{user.data?.name}</div>;
 }
 ```
 
 ## Resources
 
-- [Redux Documentation](https://redux.js.org/)
-- [Redux Thunk Documentation](https://github.com/reduxjs/redux-thunk)
-- [React Redux Documentation](https://react-redux.js.org/) 
+- [Redux Toolkit Documentation](https://redux-toolkit.js.org/)
+- [React Redux Documentation](https://react-redux.js.org/)
+- [Redux Persist Documentation](https://github.com/rt2zz/redux-persist)

--- a/extensions/react-redux-thunk/[src]/reducers/index.ts
+++ b/extensions/react-redux-thunk/[src]/reducers/index.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from 'redux';
+import { combineReducers } from '@reduxjs/toolkit';
 
-export default () =>
-  combineReducers({
-    // Add your custom reducers here
-  });
+const rootReducer = combineReducers({
+  // Add your slice reducers here
+});
+
+export default rootReducer;

--- a/extensions/react-redux-thunk/[src]/store.ts.template
+++ b/extensions/react-redux-thunk/[src]/store.ts.template
@@ -1,49 +1,42 @@
-import createSagaMiddleware from 'redux-saga';
+import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import { persistStore, persistReducer } from 'redux-persist';
-import { applyMiddleware, createStore, compose } from 'redux';
-
-import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import storage from 'redux-persist/lib/storage';
 
-import { StoreType } from '<%= projectImportPath %>types/store';
-import reducers from '<%= projectImportPath %>reducers';
-import rootSaga from '<%= projectImportPath %>sagas';
+import rootReducer from '<%= projectImportPath %>reducers';
 
 const persistConfig = {
   key: 'root',
   storage,
   blacklist: [],
-  stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
 };
 
-const packages = [];
-const enhancers = [];
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
-// Saga
-const sagaMiddleware = createSagaMiddleware();
+const middleware = (getDefaultMiddleware: ReturnType<typeof configureStore>['middleware']) => {
+  const middlewares = getDefaultMiddleware({
+    serializableCheck: {
+      ignoredActions: ['persist/PERSIST', 'persist/REHYDRATE'],
+    },
+  });
 
-// Push middleware that you need for both development and production
-packages.push(sagaMiddleware);
-
-if (import.meta.env.DEV) {
-  // Push the middleware that are specific for development
-  packages.push(createLogger());
-  if (window.__REDUX_DEVTOOLS_EXTENSION__) {
-    enhancers.push(window.__REDUX_DEVTOOLS_EXTENSION__());
+  if (import.meta.env.DEV) {
+    middlewares.concat(createLogger() as any);
   }
-}
 
-const middleware = applyMiddleware(...packages);
+  return middlewares;
+};
 
-export const store = createStore(
-  persistReducer<StoreType>(persistConfig, reducers()),
-  compose(middleware, ...enhancers),
-);
-
-sagaMiddleware.run(rootSaga);
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware,
+  devTools: import.meta.env.DEV,
+});
 
 export const persistor = persistStore(store);
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
 
 export default {
   store,

--- a/extensions/react-redux-thunk/[src]/types/global.d.ts
+++ b/extensions/react-redux-thunk/[src]/types/global.d.ts
@@ -1,4 +1,0 @@
-declare interface Window {
-  __REDUX_DEVTOOLS_EXTENSION__: any;
-  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any;
-}

--- a/extensions/react-redux-thunk/[src]/types/store.ts
+++ b/extensions/react-redux-thunk/[src]/types/store.ts
@@ -1,3 +1,4 @@
-import { CombinedState } from "redux";
+import type { store } from '<%= projectImportPath %>store';
 
-export type StoreType = CombinedState<object>
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/extensions/react-redux-thunk/package.json
+++ b/extensions/react-redux-thunk/package.json
@@ -1,13 +1,11 @@
 {
   "dependencies": {
-    "react-redux": "^9.0.2",
-    "redux": "^5.0.1",
+    "@reduxjs/toolkit": "^2.5.0",
+    "react-redux": "^9.2.0",
     "redux-logger": "^3.0.6",
-    "redux-persist": "^6.0.0",
-    "redux-thunk": "^3.1.0"
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
-    "@types/redux-logger": "^3.0.13",
-    "@types/react-redux": "^7.1.34"
+    "@types/redux-logger": "^3.0.13"
   }
 }

--- a/templates.json
+++ b/templates.json
@@ -386,19 +386,6 @@
       ]
     },
     {
-      "name": "Recoil.js (Deprecated)",
-      "slug": "recoil-js",
-      "description": "Extension to add Recoil.js, a state management library for React that lets you a data-flow graph that flows from atoms",
-      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-recoil",
-      "type": "react",
-      "category": "State Management",
-      "labels": [
-        "Recoil.js",
-        "State Management",
-        "Atomic State Management"
-      ]
-    },
-    {
       "name": "Jotai",
       "slug": "jotai",
       "description": "Extension to add Jotai, a small and fast state management library for React",
@@ -407,6 +394,19 @@
       "category": "State Management",
       "labels": [
         "Jotai",
+        "State Management",
+        "Atomic State Management"
+      ]
+    },
+    {
+      "name": "Recoil.js (Deprecated)",
+      "slug": "recoil-js",
+      "description": "Extension to add Recoil.js, a state management library for React. Note: Recoil is no longer maintained by Meta (formerly Facebook Experimental) and may not receive future updates.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-recoil",
+      "type": "react",
+      "category": "State Management",
+      "labels": [
+        "Recoil.js",
         "State Management",
         "Atomic State Management"
       ]
@@ -530,7 +530,7 @@
     {
       "name": "React Redux with Redux Saga",
       "slug": "react-redux-saga",
-      "description": "Extension to add the official React bindings for Redux with a fully configured store using Redux Saga",
+      "description": "Extension to add Redux Toolkit (RTK) with React Redux bindings and Redux Saga for side-effect management",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-redux-saga",
       "type": "react",
       "category": "State Management",
@@ -544,9 +544,9 @@
       ]
     },
     {
-      "name": "React Redux with Redux Thunk",
+      "name": "React Redux with Redux Toolkit",
       "slug": "react-redux-thunk",
-      "description": "Extension to add the official React bindings for Redux with a fully configured store using Redux Thunk",
+      "description": "Extension to add Redux Toolkit (RTK) with React Redux bindings, redux-persist, and redux-logger for a fully configured store",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-redux-thunk",
       "type": "react",
       "category": "State Management",


### PR DESCRIPTION
## Summary

- **Modernize `react-redux-thunk`** to use `@reduxjs/toolkit` (`configureStore`) instead of legacy `createStore` + `applyMiddleware`
  - Fixes `CombinedState` import error (type removed in Redux 5.x) — root cause of `react-vite-boilerplate` CI failures
  - Removes accidental saga imports (copy-paste bug from the saga extension)
  - Adds proper `RootState` / `AppDispatch` TypeScript types
  - Built-in DevTools support (no more `window.__REDUX_DEVTOOLS_EXTENSION__`)
  
- **Modernize `react-redux-saga`** to use `@reduxjs/toolkit` + saga middleware
  - Same `CombinedState` and DevTools fixes
  - Saga middleware integrated via RTK's `middleware` option

- **Cleanup**
  - Remove orphaned `react-ionic/` directory (only contained `.npmrc`, not listed in `templates.json`)
  - Update Recoil.js description to note Meta no longer maintains it
  - Update `templates.json` descriptions for both Redux extensions

- **Re-enable `type-check` in CI** — removes `|| true` workaround that was masking real TypeScript errors

## Testing

CI will run the random template+extension combinations. The `react-vite-boilerplate` + `react-redux-thunk` combo that was previously failing should now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow now properly fails when type-checking encounters errors instead of continuing.

* **New Features**
  * Redux state management extensions now use Redux Toolkit with improved type safety and modern APIs.

* **Updates**
  * Redux Saga and Redux Thunk extensions refactored to use Redux Toolkit's `configureStore` and async handling patterns.
  * Updated template descriptions and reordered state management options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->