### PR TITLE
chore: remove abandoned extensions, deprecate low-adoption ones

### DIFF
--- a/extensions/react-easy-state/package.json
+++ b/extensions/react-easy-state/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@risingstack/react-easy-state": "^6.3.0"
-  }
-}

--- a/extensions/react-global-state/package.json
+++ b/extensions/react-global-state/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "react-hooks-global-state": "^2.1.0"
-  }
-}

--- a/templates.json
+++ b/templates.json
@@ -412,36 +412,6 @@
       ]
     },
     {
-      "name": "Easy State",
-      "slug": "easy-state",
-      "description": "Add Easy State, a lightweight state management solution with a simple API and automatic reactivity.",
-      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-easy-state",
-      "type": "react",
-      "category": "State Management",
-      "labels": [
-        "Easy State",
-        "State Management",
-        "React Hooks",
-        "TypeScript",
-        "Cursor Rules"
-      ]
-    },
-    {
-      "name": "Global State",
-      "slug": "global-state",
-      "description": "Add Global State, a minimal state management solution for React applications with global state support.",
-      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-global-state",
-      "type": "react",
-      "category": "State Management",
-      "labels": [
-        "Global State",
-        "State Management",
-        "React Hooks",
-        "TypeScript",
-        "Cursor Rules"
-      ]
-    },
-    {
       "name": "Hookstate",
       "slug": "hookstate",
       "description": "Add Hookstate, a modern state management solution with hooks-based API and TypeScript support.",
@@ -470,9 +440,9 @@
       ]
     },
     {
-      "name": "Teaful",
+      "name": "Teaful (Deprecated)",
       "slug": "teaful",
-      "description": "Add Teaful, a tiny and fast state management solution with a simple API and TypeScript support.",
+      "description": "Add Teaful, a tiny and fast state management solution with a simple API and TypeScript support. Note: Teaful has very low adoption (~126 weekly downloads) and may not receive future updates.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-teaful",
       "type": "react",
       "category": "State Management",


### PR DESCRIPTION
## Summary

- **Remove** `react-easy-state` extension — `@risingstack/react-easy-state` is abandoned (last publish 2022, no maintainer activity)
- **Remove** `react-global-state` extension — `react-hooks-global-state` is abandoned (last publish 2022)
- **Deprecate** `react-teaful` — mark as "(Deprecated)" in `templates.json` with notice about ~126 weekly downloads and pre-1.0 stability

## Context

| Extension | Package | Weekly Downloads | Status |
|-----------|---------|-----------------|--------|
| `react-easy-state` | `@risingstack/react-easy-state` | ~low | **Removed** — abandoned |
| `react-global-state` | `react-hooks-global-state` | ~low | **Removed** — abandoned |
| `react-teaful` | `teaful` | ~126 | **Deprecated** — very low adoption |
| `react-recoil` | `recoil` | kept | Already deprecated in PR #60 |
| `react-hookstate` | `@hookstate/core` | ~74,400 | **Kept** — healthy |
| `react-million` | `million` | ~31,020 | **Kept** — active |

## Files changed

- `extensions/react-easy-state/package.json` — deleted
- `extensions/react-global-state/package.json` — deleted
- `templates.json` — removed 2 entries, added deprecation notice to Teaful