### PR TITLE
fix(react-redux-saga): add missing app-providers composable pattern

### DIFF
--- a/extensions/react-redux-saga/[src]/app-providers.tsx.append.template
+++ b/extensions/react-redux-saga/[src]/app-providers.tsx.append.template
@@ -1,5 +1,7 @@
 
 import { Provider as ReduxSagaProvider } from 'react-redux';
-import { store } from '<%= projectImportPath %>store';
+import { store as reduxSagaStore } from '<%= projectImportPath %>store';
 
-appProviders.push((children) => <ReduxSagaProvider store={store}>{children}</ReduxSagaProvider>);
+appProviders.push((children) => (
+  <ReduxSagaProvider store={reduxSagaStore}>{children}</ReduxSagaProvider>
+));

--- a/extensions/react-redux-saga/[src]/app-providers.tsx.append.template
+++ b/extensions/react-redux-saga/[src]/app-providers.tsx.append.template
@@ -1,0 +1,5 @@
+
+import { Provider as ReduxSagaProvider } from 'react-redux';
+import { store } from '<%= projectImportPath %>store';
+
+appProviders.push((children) => <ReduxSagaProvider store={store}>{children}</ReduxSagaProvider>);


### PR DESCRIPTION
## Summary

- The `f04616e` refactor removed `App.tsx.template` overrides from all state-management extensions in favor of the new `app-providers.tsx.append.template` composable pattern
- `react-redux-saga` had its `App.tsx.template` deleted but was **not** given a `app-providers.tsx.append.template`, leaving the app without a Redux `Provider` when this extension is used
- This PR adds the missing file, mirroring the pattern already used by `react-redux-thunk`

## Root cause of the June 21 CI failure (Run #27893970322)

The CI failed on `ccbb30f` due to conflicting full-file overrides when ALL extensions were combined:

- `nextjs-starter` — both `nextjs-auth` and `nextjs-i18n` had their own `middleware.ts.template` which merged into a garbled file
- `react-vite-boilerplate` — four extensions had their own `App.tsx.template` and three had their own `Loading.tsx`, producing broken output when combined

Those root causes were already fixed in `f04616e`. This PR fixes the remaining gap: the missing Redux provider registration for `react-redux-saga`.

## Test plan

- [ ] Generate a project using `react-vite-boilerplate` template + `react-redux-saga` extension and verify the Redux `Provider` wraps the app
- [ ] Run the full CI matrix to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)