### PR TITLE
fix: align Drizzle versions, upgrade CI actions, and document matrix

### DIFF
--- a/.github/workflows/test-combinations.yml
+++ b/.github/workflows/test-combinations.yml
@@ -26,10 +26,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -94,10 +94,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -137,10 +137,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -203,10 +203,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ npx create-awesome-node-app --template react-vite-boilerplate --addons material-
 | [docs/TESTING.md](./docs/TESTING.md) | Local testing and CI workflow |
 | [CONTRIBUTING.md](./CONTRIBUTING.md) | How to add templates and extensions |
 
+## CI compatibility matrix
+
+The badge above reflects the [test-combinations workflow](./.github/workflows/test-combinations.yml):
+
+- **On every PR:** a randomized subset of template × extension combinations
+- **Weekly (Sunday UTC):** full matrix — every template with all compatible extensions
+
+See the [Actions tab](https://github.com/Create-Node-App/cna-templates/actions/workflows/test-combinations.yml) for the latest run results.
+
 ## Support
 
 - 📦 [NPM Package](https://www.npmjs.com/package/create-awesome-node-app)

--- a/extensions/nestjs-drizzle-postgres/.env.example.append
+++ b/extensions/nestjs-drizzle-postgres/.env.example.append
@@ -3,3 +3,4 @@ POSTGRES_USER='user'
 POSTGRES_PASSWORD='user1234'
 POSTGRES_HOST='postgresql' # Or localhost if you are running the NestJS app outside of the compose network
 POSTGRES_PORT='5432'
+DATABASE_URL='postgres://user:user1234@postgresql:5432/postgres'

--- a/extensions/nestjs-drizzle-postgres/drizzle.config.json
+++ b/extensions/nestjs-drizzle-postgres/drizzle.config.json
@@ -1,4 +1,0 @@
-{
-  "out": "./src/db/migrations",
-  "schema": "./src/db/schema.ts"
-}

--- a/extensions/nestjs-drizzle-postgres/drizzle.config.ts
+++ b/extensions/nestjs-drizzle-postgres/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './src/db/migrations',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/extensions/nestjs-drizzle-postgres/drizzle.config.ts
+++ b/extensions/nestjs-drizzle-postgres/drizzle.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'drizzle-kit';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',

--- a/extensions/nestjs-drizzle-postgres/package.json
+++ b/extensions/nestjs-drizzle-postgres/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",
+    "dotenv": "^17.2.3",
     "drizzle-kit": "^0.31.8"
   }
 }

--- a/extensions/nestjs-drizzle-postgres/package.json
+++ b/extensions/nestjs-drizzle-postgres/package.json
@@ -1,14 +1,17 @@
 {
   "scripts": {
-    "drizzle:migrate": "drizzle-kit generate:pg"
+    "drizzle:generate": "drizzle-kit generate",
+    "drizzle:migrate": "drizzle-kit migrate",
+    "drizzle:push": "drizzle-kit push",
+    "drizzle:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.744.0",
-    "drizzle-orm": "^0.39.3",
+    "drizzle-orm": "^0.45.1",
     "pg": "^8.13.3"
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",
-    "drizzle-kit": "^0.30.4"
+    "drizzle-kit": "^0.31.8"
   }
 }

--- a/extensions/nestjs-drizzle-sqlite/drizzle.config.json
+++ b/extensions/nestjs-drizzle-sqlite/drizzle.config.json
@@ -1,4 +1,0 @@
-{
-  "out": "./src/db/migrations",
-  "schema": "./src/db/schema.ts"
-}

--- a/extensions/nestjs-drizzle-sqlite/drizzle.config.ts
+++ b/extensions/nestjs-drizzle-sqlite/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './src/db/migrations',
+  dialect: 'sqlite',
+  dbCredentials: {
+    url: process.env.DATABASE_URL || 'file:./local.db',
+  },
+});

--- a/extensions/nestjs-drizzle-sqlite/package.json
+++ b/extensions/nestjs-drizzle-sqlite/package.json
@@ -1,12 +1,15 @@
 {
   "scripts": {
-    "drizzle:migrate": "drizzle-kit generate:sqlite"
+    "drizzle:generate": "drizzle-kit generate",
+    "drizzle:migrate": "drizzle-kit migrate",
+    "drizzle:push": "drizzle-kit push",
+    "drizzle:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "drizzle-orm": "^0.39.3",
+    "drizzle-orm": "^0.45.1",
     "better-sqlite3": "^11.8.1"
   },
   "devDependencies": {
-    "drizzle-kit": "^0.30.4"
+    "drizzle-kit": "^0.31.8"
   }
 }

--- a/extensions/react-recoil/README.md
+++ b/extensions/react-recoil/README.md
@@ -1,5 +1,7 @@
 # React Recoil Extension
 
+> **Deprecation notice:** Recoil has had minimal maintenance since 2020 and Meta has not announced a successor. This extension remains available for legacy projects, but **new projects should prefer [Jotai](../react-jotai) or [Zustand](../react-zustand)**. This extension may be removed in a future major release of the template catalog.
+
 This extension adds Recoil state management to your React application with atomic state management and fine-grained reactivity.
 
 ## Features

--- a/extensions/react-recoil/README.md
+++ b/extensions/react-recoil/README.md
@@ -1,6 +1,6 @@
 # React Recoil Extension
 
-> **Deprecation notice:** Recoil has had minimal maintenance since 2020 and Meta has not announced a successor. This extension remains available for legacy projects, but **new projects should prefer [Jotai](../react-jotai) or [Zustand](../react-zustand)**. This extension may be removed in a future major release of the template catalog.
+> **Deprecation notice:** Recoil has had limited maintenance in recent years and Meta has not announced a successor. This extension remains available for legacy projects, but **new projects should prefer [Jotai](../react-jotai) or [Zustand](../react-zustand)**. This extension may be removed in a future major release of the template catalog.
 
 This extension adds Recoil state management to your React application with atomic state management and fine-grained reactivity.
 


### PR DESCRIPTION
## Summary
- Align NestJS Drizzle extensions to `drizzle-orm ^0.45.1` and `drizzle-kit ^0.31.8` (#64)
- Migrate NestJS Drizzle configs from JSON to `drizzle.config.ts` with `defineConfig`
- Upgrade `actions/checkout` and `actions/setup-node` to v5 (#67)
- Document CI compatibility matrix in README (#85)
- Add Recoil deprecation notice to extension README (#66)

## Test plan
- [ ] `test-combinations` workflow passes on PR
- [ ] No Node.js 20 deprecation warnings in CI output

Closes #64, #66, #67, #85

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a CI compatibility matrix section to the README, including how often different test runs occur and where to view the latest results.
  * Added a deprecation notice for the Recoil extension, with guidance toward newer alternatives.

* **Chores**
  * Updated CI and project tooling to newer supported versions.
  * Refreshed database-related setup for PostgreSQL and SQLite extensions to align with current command and configuration conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->