### PR TITLE
fix: address CodeRabbit review feedback from #87

### DIFF
--- a/.github/workflows/test-combinations.yml
+++ b/.github/workflows/test-combinations.yml
@@ -26,10 +26,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
 
@@ -94,10 +94,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
 
@@ -137,10 +137,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
 
@@ -203,10 +203,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --addons material-
 
 The badge above reflects the [test-combinations workflow](./.github/workflows/test-combinations.yml):
 
+- **On push to `main`:** a randomized subset of template × extension combinations
 - **On every PR:** a randomized subset of template × extension combinations
 - **Weekly (Sunday UTC):** full matrix — every template with all compatible extensions
 


### PR DESCRIPTION
## Summary
Follow-up to #87 addressing [CodeRabbit review comments](https://github.com/Create-Node-App/cna-templates/pull/87#pullrequestreview-4565662339):

- Pin `actions/checkout` and `actions/setup-node` to commit SHAs in `test-combinations.yml` (security / zizmor compliance)
- Document push-to-`main` runs in the README CI compatibility matrix section

## Context
CodeRabbit posted 2 actionable comments on #87 after merge. PR #131 (create-node-app) had no actionable CodeRabbit feedback (rate limit reached).

## Test plan
- [ ] `test-combinations` workflow passes on PR

Made with [Cursor](https://cursor.com)