### PR TITLE
NestJS 11, env validation, error boundary, and t3-env extension

### DIFF
--- a/extensions/nextjs-t3-env/.env.example.append
+++ b/extensions/nextjs-t3-env/.env.example.append
@@ -1,6 +1,3 @@
-# Application
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXT_PUBLIC_APP_NAME=My App
 
 # Set to true in CI or Docker builds when env vars are not available at build time
 # SKIP_ENV_VALIDATION=true

--- a/extensions/nextjs-t3-env/README.md
+++ b/extensions/nextjs-t3-env/README.md
@@ -1,0 +1,20 @@
+# t3-env for Next.js
+
+Adds [`@t3-oss/env-nextjs`](https://env.t3.gg/) with a Zod schema for server and client environment variables.
+
+## Generated files
+
+- `src/env.ts` — validated `env` export (path follows your `srcDir` choice)
+- Startup validation runs via the base template `instrumentation.ts` hook
+
+## Usage
+
+```typescript
+import { env } from '@/env';
+
+const appName = env.NEXT_PUBLIC_APP_NAME;
+```
+
+## CI / Docker
+
+Set `SKIP_ENV_VALIDATION=true` when environment variables are injected at runtime instead of build time.

--- a/extensions/nextjs-t3-env/[src]/env.ts.template
+++ b/extensions/nextjs-t3-env/[src]/env.ts.template
@@ -1,0 +1,24 @@
+import { createEnv } from '@t3-oss/env-nextjs';
+import { z } from 'zod';
+
+/**
+ * Type-safe environment variables with server/client split.
+ *
+ * @see https://env.t3.gg/docs/nextjs
+ */
+export const env = createEnv({
+  server: {
+    NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  },
+  client: {
+    NEXT_PUBLIC_APP_URL: z.url().default('http://localhost:3000'),
+    NEXT_PUBLIC_APP_NAME: z.string().min(1).default('My App'),
+  },
+  runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
+  },
+  skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+  emptyStringAsUndefined: true,
+});

--- a/extensions/nextjs-t3-env/package.json
+++ b/extensions/nextjs-t3-env/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@t3-oss/env-nextjs": "^0.13.11",
+    "zod": "^4.4.3"
+  }
+}

--- a/extensions/react-i18n/[src]/main.tsx.template
+++ b/extensions/react-i18n/[src]/main.tsx.template
@@ -1,14 +1,20 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { AppErrorBoundary } from '<%= projectImportPath %>components/ErrorBoundary';
 import '<%= projectImportPath%>i18n';
 import reportWebVitals from '<%= projectImportPath%>report-web-vitals';
+import { setupGlobalErrorHandlers } from '<%= projectImportPath %>utils/report-error';
 import App from '<%= projectImportPath%>App';
+
+setupGlobalErrorHandlers();
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
   </React.StrictMode>,
 );
 

--- a/templates.json
+++ b/templates.json
@@ -849,6 +849,21 @@
       ]
     },
     {
+      "name": "t3-env for Next.js",
+      "slug": "nextjs-t3-env",
+      "description": "Add type-safe environment variable validation with @t3-oss/env-nextjs and Zod, including server/client split and SKIP_ENV_VALIDATION for CI.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/nextjs-t3-env",
+      "type": "nextjs",
+      "category": "Tooling",
+      "labels": [
+        "t3-env",
+        "Environment",
+        "Zod",
+        "Validation",
+        "TypeScript"
+      ]
+    },
+    {
       "name": "next-intl (i18n) for Next.js",
       "slug": "nextjs-i18n",
       "description": "Add internationalization to your Next.js project using next-intl with English and Spanish translations, middleware routing, and type-safe message access.",

--- a/templates/nestjs-starter/package/dependencies.js
+++ b/templates/nestjs-starter/package/dependencies.js
@@ -1,8 +1,8 @@
 module.exports = {
-  "@nestjs/common": "^10.0.0",
-  "@nestjs/config": "^3.0.0",
-  "@nestjs/core": "^10.0.0",
-  "@nestjs/platform-express": "^10.0.0",
-  "reflect-metadata": "^0.1.13",
+  "@nestjs/common": "^11.1.0",
+  "@nestjs/config": "^4.0.0",
+  "@nestjs/core": "^11.1.0",
+  "@nestjs/platform-express": "^11.1.0",
+  "reflect-metadata": "^0.2.2",
   "rxjs": "^7.8.1"
 };

--- a/templates/nestjs-starter/package/devDependencies.js
+++ b/templates/nestjs-starter/package/devDependencies.js
@@ -1,7 +1,7 @@
 module.exports = {
-  "@nestjs/cli": "^10.0.1",
-  "@nestjs/schematics": "^10.0.1",
-  "@nestjs/testing": "^10.0.0",
+  "@nestjs/cli": "^11.0.0",
+  "@nestjs/schematics": "^11.0.0",
+  "@nestjs/testing": "^11.0.0",
   "@swc/cli": "^0.1.62",
   "@swc/core": "^1.3.64",
   "@types/express": "^4.17.17",

--- a/templates/nextjs-starter/[src]/env.ts
+++ b/templates/nextjs-starter/[src]/env.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  NEXT_PUBLIC_APP_URL: z.url().default('http://localhost:3000'),
+  NEXT_PUBLIC_APP_NAME: z.string().min(1).default('My App'),
+});
+
+function parseEnv() {
+  const skipValidation = process.env.SKIP_ENV_VALIDATION === 'true';
+
+  if (skipValidation) {
+    return envSchema.parse({
+      NODE_ENV: process.env.NODE_ENV ?? 'development',
+      NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000',
+      NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME ?? 'My App',
+    });
+  }
+
+  return envSchema.parse(process.env);
+}
+
+export const env = parseEnv();

--- a/templates/nextjs-starter/instrumentation.ts.template
+++ b/templates/nextjs-starter/instrumentation.ts.template
@@ -1,0 +1,5 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./<%= srcDir %>/env');
+  }
+}

--- a/templates/nextjs-starter/package.json
+++ b/templates/nextjs-starter/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "^16.1.6",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.1.6",

--- a/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,20 @@
+import { ErrorBoundary } from 'react-error-boundary';
+
+import ErrorFallback from './ErrorFallback';
+
+type AppErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+export default function AppErrorBoundary({ children }: AppErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onReset={() => {
+        window.location.reload();
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorFallback.module.css
+++ b/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorFallback.module.css
@@ -1,0 +1,36 @@
+.container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.message {
+  color: #555;
+  margin: 0;
+  max-width: 40rem;
+}
+
+.button {
+  background: #111;
+  border: none;
+  border-radius: 0.375rem;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.625rem 1.25rem;
+}
+
+.button:hover {
+  background: #333;
+}

--- a/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorFallback.tsx
+++ b/templates/react-vite-starter/[src]/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,0 +1,17 @@
+import type { FallbackProps } from 'react-error-boundary';
+
+import styles from './ErrorFallback.module.css';
+
+export default function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+
+  return (
+    <div className={styles.container} role="alert">
+      <h1 className={styles.title}>Something went wrong</h1>
+      <p className={styles.message}>{message}</p>
+      <button type="button" className={styles.button} onClick={resetErrorBoundary}>
+        Reload
+      </button>
+    </div>
+  );
+}

--- a/templates/react-vite-starter/[src]/components/ErrorBoundary/index.ts
+++ b/templates/react-vite-starter/[src]/components/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { default as AppErrorBoundary } from './ErrorBoundary';
+export { default as ErrorFallback } from './ErrorFallback';

--- a/templates/react-vite-starter/[src]/main.tsx.template
+++ b/templates/react-vite-starter/[src]/main.tsx.template
@@ -1,13 +1,19 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { AppErrorBoundary } from '<%= projectImportPath %>components/ErrorBoundary';
 import reportWebVitals from '<%= projectImportPath%>report-web-vitals';
+import { setupGlobalErrorHandlers } from '<%= projectImportPath %>utils/report-error';
 import App from '<%= projectImportPath%>App';
+
+setupGlobalErrorHandlers();
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
   </React.StrictMode>,
 );
 

--- a/templates/react-vite-starter/[src]/utils/report-error.ts
+++ b/templates/react-vite-starter/[src]/utils/report-error.ts
@@ -1,0 +1,31 @@
+type ErrorContext = Record<string, unknown>;
+
+/**
+ * Default error reporter (no-op in production). Extensions such as Sentry can
+ * replace this at bootstrap time.
+ */
+let reportErrorImpl: (error: unknown, context?: ErrorContext) => void = (error, context) => {
+  if (import.meta.env.DEV) {
+    console.error('[report-error]', error, context);
+  }
+};
+
+export function setErrorReporter(
+  reporter: (error: unknown, context?: ErrorContext) => void,
+): void {
+  reportErrorImpl = reporter;
+}
+
+export function reportError(error: unknown, context?: ErrorContext): void {
+  reportErrorImpl(error, context);
+}
+
+export function setupGlobalErrorHandlers(): void {
+  window.addEventListener('error', (event) => {
+    reportError(event.error ?? event.message, { source: 'window.onerror' });
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    reportError(event.reason, { source: 'unhandledrejection' });
+  });
+}

--- a/templates/react-vite-starter/package/dependencies.js
+++ b/templates/react-vite-starter/package/dependencies.js
@@ -1,6 +1,7 @@
 module.exports = {
   react: "^19.0.0",
   "react-dom": "^19.0.0",
+  "react-error-boundary": "^6.1.2",
   "react-router-dom": "^7.1.5",
   "web-vitals": "^4.2.4",
 };


### PR DESCRIPTION
## Summary
- **#79** — Align `nestjs-starter` with NestJS 11 (`@nestjs/*`, CLI, testing, config v4)
- **#78** — Add Zod-based `env.ts` + `instrumentation.ts` to `nextjs-starter` with `SKIP_ENV_VALIDATION` support
- **#80** — Add root `ErrorBoundary`, fallback UI, and `report-error` utility to `react-vite-starter`
- **#68** — New `nextjs-t3-env` extension with `@t3-oss/env-nextjs` server/client split

## Notes
- **#65** (next-auth stable) not included — v5 stable is not published yet (latest: `5.0.0-beta.31`)

## Test plan
- [ ] CI matrix passes for `nestjs-boilerplate`, `nextjs-starter`, `react-vite-boilerplate`
- [ ] Scaffolded nextjs-starter fails clearly when required env vars are invalid
- [ ] react-vite error boundary shows fallback on component throw

Closes #79
Closes #78
Closes #80
Closes #68

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Next.js environment configuration template with type-safe app settings and optional validation skipping for CI/Docker builds.
  * Added a React error boundary setup with a polished fallback UI and automatic page reload on recovery.
  * Included a new template entry for the Next.js environment tooling package.

* **Bug Fixes**
  * Improved startup handling so app errors are caught and displayed instead of breaking the page.

* **Documentation**
  * Added setup guidance for environment validation and runtime environment variables.

* **Chores**
  * Updated starter dependencies to newer NestJS and React error boundary-compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->