### PR TITLE
Vitest and Playwright testing extensions

### DIFF
--- a/extensions/react-playwright/.github/workflows/e2e.yml
+++ b/extensions/react-playwright/.github/workflows/e2e.yml
@@ -1,0 +1,37 @@
+name: E2E tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e -- --project=chromium

--- a/extensions/react-playwright/.gitignore.append
+++ b/extensions/react-playwright/.gitignore.append
@@ -1,0 +1,4 @@
+
+/playwright-report/
+/test-results/
+/blob-report/

--- a/extensions/react-playwright/README.md
+++ b/extensions/react-playwright/README.md
@@ -1,0 +1,24 @@
+# Playwright E2E testing
+
+End-to-end browser tests with Playwright, including a dev-server bootstrap and cross-browser projects.
+
+## Scripts
+
+- `npm run test:e2e` — run Playwright tests (starts `npm run dev` automatically)
+- `npm run test:e2e:ui` — interactive UI mode
+
+## Generated files
+
+- `playwright.config.ts` — chromium, firefox, and webkit projects
+- `e2e/example.spec.ts` — smoke test against the home page
+- `.github/workflows/e2e.yml` — CI job (chromium) when this extension is included
+
+## CI
+
+Install browsers once per runner:
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+When combined with `all-github-setup`, the bundled `tests.yml` workflow runs unit tests; this extension adds a dedicated E2E workflow.

--- a/extensions/react-playwright/docs/README.md.append
+++ b/extensions/react-playwright/docs/README.md.append
@@ -1,0 +1,4 @@
+
+## E2E testing (Playwright)
+
+Run browser tests with `npm run test:e2e`. See the [Playwright extension README](https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-playwright).

--- a/extensions/react-playwright/e2e/example.spec.ts
+++ b/extensions/react-playwright/e2e/example.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('App smoke test', () => {
+  test('home page loads with a visible heading', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  });
+});

--- a/extensions/react-playwright/package.json
+++ b/extensions/react-playwright/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  },
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  }
+}

--- a/extensions/react-playwright/playwright.config.ts
+++ b/extensions/react-playwright/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = process.env.PORT ?? '3000';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${port}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/extensions/react-testing-library-with-vitest/README.md
+++ b/extensions/react-testing-library-with-vitest/README.md
@@ -1,0 +1,18 @@
+# Vitest + React Testing Library
+
+Vite-native unit and integration testing with Vitest, jsdom, and React Testing Library.
+
+## Scripts
+
+- `npm run test` — run tests once
+- `npm run test:watch` — watch mode
+- `npm run test:coverage` — coverage via `@vitest/coverage-v8`
+- `npm run test:ui` — Vitest UI
+
+## Generated files
+
+- `vitest.config.ts` — shares path aliases with the Vite app
+- `src/setupTests.ts` — Testing Library matchers
+- `src/pages/Landing.test.tsx` — example smoke test
+
+See [docs/TESTING_GUIDE.md](./docs/TESTING_GUIDE.md) for patterns.

--- a/extensions/react-testing-library-with-vitest/[src]/pages/Landing.test.tsx.template
+++ b/extensions/react-testing-library-with-vitest/[src]/pages/Landing.test.tsx.template
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Landing from '<%= projectImportPath %>pages/Landing';
+
+describe('Landing', () => {
+  it('renders the project title', () => {
+    render(<Landing />);
+
+    expect(screen.getByRole('heading', { level: 1, name: '<%= projectName %>' })).toBeInTheDocument();
+  });
+});

--- a/extensions/react-testing-library-with-vitest/[src]/setupTests.ts
+++ b/extensions/react-testing-library-with-vitest/[src]/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/extensions/react-testing-library-with-vitest/docs/README.md.append
+++ b/extensions/react-testing-library-with-vitest/docs/README.md.append
@@ -1,0 +1,4 @@
+
+## Testing (Vitest)
+
+This project uses Vitest with React Testing Library. See [docs/TESTING_GUIDE.md](./docs/TESTING_GUIDE.md).

--- a/extensions/react-testing-library-with-vitest/docs/TESTING_GUIDE.md
+++ b/extensions/react-testing-library-with-vitest/docs/TESTING_GUIDE.md
@@ -1,0 +1,32 @@
+# Vitest + React Testing Library Guide
+
+## Quick start
+
+```bash
+npm run test
+npm run test:watch
+npm run test:coverage
+```
+
+## Example
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Click me</Button>);
+
+    screen.getByRole('button', { name: 'Click me' }).click();
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+});
+```
+
+## Resources
+
+- [Vitest](https://vitest.dev/)
+- [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)

--- a/extensions/react-testing-library-with-vitest/package.json
+++ b/extensions/react-testing-library-with-vitest/package.json
@@ -1,0 +1,17 @@
+{
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/ui": "^4.1.9",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.9"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:ui": "vitest --ui"
+  }
+}

--- a/extensions/react-testing-library-with-vitest/vitest.config.ts.template
+++ b/extensions/react-testing-library-with-vitest/vitest.config.ts.template
@@ -1,0 +1,25 @@
+import path from 'path';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+const srcDir = path.resolve(__dirname, '<%= srcDir%>');
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '<%= projectImportPath%>': path.join(srcDir, '/'),
+    },
+  },
+  test: {
+    dir: srcDir,
+    environment: 'jsdom',
+    setupFiles: [path.join(srcDir, 'setupTests.ts')],
+    include: ['**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+    },
+    css: true,
+  },
+});

--- a/templates.json
+++ b/templates.json
@@ -343,6 +343,38 @@
       ]
     },
     {
+      "name": "Vitest + React Testing Library",
+      "slug": "vitest-react-testing-library",
+      "description": "Add Vitest and React Testing Library for fast Vite-native unit and integration testing in React projects.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-testing-library-with-vitest",
+      "type": "react",
+      "category": "Testing",
+      "labels": [
+        "Vitest",
+        "React Testing Library",
+        "Unit Testing",
+        "Integration Testing",
+        "Vite"
+      ]
+    },
+    {
+      "name": "Playwright E2E",
+      "slug": "react-playwright",
+      "description": "Add Playwright end-to-end browser testing with multi-browser config, dev-server bootstrap, and CI workflow.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/react-playwright",
+      "type": [
+        "react",
+        "nextjs"
+      ],
+      "category": "Testing",
+      "labels": [
+        "Playwright",
+        "E2E",
+        "Browser Testing",
+        "CI"
+      ]
+    },
+    {
       "name": "React i18n",
       "slug": "react-i18n",
       "description": "Add internationalization support to your React app with react-i18n and async backend.",


### PR DESCRIPTION
## Summary
- **#69** — New `react-testing-library-with-vitest` extension (Vitest 4, RTL, jsdom, coverage-v8, example test)
- **#74** — New `react-playwright` extension (multi-browser config, dev-server bootstrap, e2e smoke test, CI workflow)

## Test plan
- [x] Local scaffold + `npm run test` passes with Vitest extension on `react-vite-starter`
- [ ] CI matrix passes for all template combinations
- [ ] Playwright `test:e2e` runs against dev server (chromium in CI)

Closes #69
Closes #74

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added React testing extensions for both Playwright end-to-end testing and Vitest + React Testing Library.
  * Included ready-to-run test scripts and sample test setups for React projects.
  * Added CI support to automatically run browser tests on pushes and pull requests.

* **Documentation**
  * Added setup and usage guides for both testing options.
  * Expanded docs with quick-start instructions and examples for running and writing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->