### PR TITLE
Add nextjs-trpc extension for type-safe App Router APIs

### DIFF
--- a/extensions/nextjs-trpc/README.md
+++ b/extensions/nextjs-trpc/README.md
@@ -1,0 +1,30 @@
+# tRPC for Next.js
+
+Adds [tRPC v11](https://trpc.io/) with TanStack Query and the App Router fetch adapter for end-to-end type-safe APIs.
+
+## Generated files
+
+- `src/server/trpc.ts` — tRPC initialization and context
+- `src/server/routers/index.ts` — root router with an example `hello` procedure
+- `src/utils/query-client.ts` — shared React Query client factory
+- `src/utils/trpc.tsx` — client hooks and `TRPCReactProvider`
+- `src/app/api/trpc/[trpc]/route.ts` — App Router handler
+- `src/app-providers.tsx` — composable provider registry (works with other CNA provider extensions)
+- `src/components/providers.tsx` — client wrapper used by the root layout
+
+## Usage
+
+```tsx
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/utils/trpc';
+
+export function Example() {
+  const trpc = useTRPC();
+  const hello = useQuery(trpc.hello.queryOptions({ text: 'world' }));
+  return <p>{hello.data?.greeting}</p>;
+}
+```
+
+See `docs/TRPC_GUIDE.md` for router and client patterns.

--- a/extensions/nextjs-trpc/[src]/app-providers.tsx.template
+++ b/extensions/nextjs-trpc/[src]/app-providers.tsx.template
@@ -1,0 +1,14 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { TRPCReactProvider } from '<%= projectImportPath %>utils/trpc';
+
+type AppProvider = (children: ReactNode) => ReactNode;
+
+export const appProviders: AppProvider[] = [
+  (children) => <TRPCReactProvider>{children}</TRPCReactProvider>,
+];
+
+export const composeAppProviders = (children: ReactNode) =>
+  appProviders.reduceRight((currentChildren, provider) => provider(currentChildren), children);

--- a/extensions/nextjs-trpc/[src]/app/api/trpc/[trpc]/route.ts.template
+++ b/extensions/nextjs-trpc/[src]/app/api/trpc/[trpc]/route.ts.template
@@ -1,0 +1,14 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+
+import { appRouter } from '<%= projectImportPath %>server/routers';
+import { createTRPCContext } from '<%= projectImportPath %>server/trpc';
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: () => createTRPCContext({ headers: req.headers }),
+  });
+
+export { handler as GET, handler as POST };

--- a/extensions/nextjs-trpc/[src]/app/layout.tsx.template
+++ b/extensions/nextjs-trpc/[src]/app/layout.tsx.template
@@ -1,0 +1,25 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+import { Providers } from '<%= projectImportPath %>components/providers';
+
+export const metadata: Metadata = {
+  title: 'Next.js Starter',
+  description: 'A polished feature-based Next.js starter generated with Create Awesome Node App',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <main className="app">
+          <Providers>{children}</Providers>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/extensions/nextjs-trpc/[src]/components/providers.tsx.template
+++ b/extensions/nextjs-trpc/[src]/components/providers.tsx.template
@@ -1,0 +1,7 @@
+'use client';
+
+import { composeAppProviders } from '<%= projectImportPath %>app-providers';
+
+export function Providers({ children }: Readonly<{ children: React.ReactNode }>) {
+  return composeAppProviders(children);
+}

--- a/extensions/nextjs-trpc/[src]/features/trpc/components/TrpcHello.tsx.template
+++ b/extensions/nextjs-trpc/[src]/features/trpc/components/TrpcHello.tsx.template
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useTRPC } from '<%= projectImportPath %>utils/trpc';
+
+export function TrpcHello() {
+  const trpc = useTRPC();
+  const hello = useQuery(trpc.hello.queryOptions({ text: 'tRPC' }));
+
+  if (hello.isLoading) {
+    return <p>Loading tRPC hello…</p>;
+  }
+
+  if (hello.isError) {
+    return <p>Unable to reach the tRPC API.</p>;
+  }
+
+  return <p>{hello.data?.greeting}</p>;
+}

--- a/extensions/nextjs-trpc/[src]/server/routers/index.ts
+++ b/extensions/nextjs-trpc/[src]/server/routers/index.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { createTRPCRouter, publicProcedure } from '../trpc';
+
+export const appRouter = createTRPCRouter({
+  hello: publicProcedure
+    .input(z.object({ text: z.string().optional() }))
+    .query(({ input }) => ({
+      greeting: `Hello ${input.text ?? 'world'}`,
+    })),
+});
+
+export type AppRouter = typeof appRouter;

--- a/extensions/nextjs-trpc/[src]/server/trpc.ts
+++ b/extensions/nextjs-trpc/[src]/server/trpc.ts
@@ -1,0 +1,15 @@
+import { initTRPC } from '@trpc/server';
+import superjson from 'superjson';
+
+export const createTRPCContext = async (opts: { headers: Headers }) => {
+  return {
+    headers: opts.headers,
+  };
+};
+
+const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
+});
+
+export const createTRPCRouter = t.router;
+export const publicProcedure = t.procedure;

--- a/extensions/nextjs-trpc/[src]/utils/query-client.ts
+++ b/extensions/nextjs-trpc/[src]/utils/query-client.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}

--- a/extensions/nextjs-trpc/[src]/utils/trpc.tsx.template
+++ b/extensions/nextjs-trpc/[src]/utils/trpc.tsx.template
@@ -1,0 +1,62 @@
+'use client';
+
+import type { QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCContext } from '@trpc/tanstack-react-query';
+import { useState } from 'react';
+import superjson from 'superjson';
+
+import type { AppRouter } from '<%= projectImportPath %>server/routers';
+import { makeQueryClient } from '<%= projectImportPath %>utils/query-client';
+
+export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>();
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient() {
+  if (typeof window === 'undefined') {
+    return makeQueryClient();
+  }
+
+  if (!browserQueryClient) {
+    browserQueryClient = makeQueryClient();
+  }
+
+  return browserQueryClient;
+}
+
+function getBaseUrl() {
+  if (typeof window !== 'undefined') {
+    return '';
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return 'http://localhost:3000';
+}
+
+export function TRPCReactProvider(props: Readonly<{ children: React.ReactNode }>) {
+  const queryClient = getQueryClient();
+
+  const [trpcClient] = useState(() =>
+    createTRPCClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          url: `${getBaseUrl()}/api/trpc`,
+          transformer: superjson,
+        }),
+      ],
+    }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        {props.children}
+      </TRPCProvider>
+    </QueryClientProvider>
+  );
+}

--- a/extensions/nextjs-trpc/docs/README.md.append
+++ b/extensions/nextjs-trpc/docs/README.md.append
@@ -1,0 +1,4 @@
+
+## tRPC
+
+This project includes a type-safe tRPC API at `/api/trpc/*` with TanStack Query on the client. See [TRPC_GUIDE.md](./TRPC_GUIDE.md).

--- a/extensions/nextjs-trpc/docs/TRPC_GUIDE.md
+++ b/extensions/nextjs-trpc/docs/TRPC_GUIDE.md
@@ -1,0 +1,48 @@
+# tRPC Guide
+
+## Server
+
+Define procedures in `src/server/routers/index.ts`:
+
+```typescript
+import { z } from 'zod';
+import { createTRPCRouter, publicProcedure } from '../trpc';
+
+export const appRouter = createTRPCRouter({
+  hello: publicProcedure
+    .input(z.object({ text: z.string().optional() }))
+    .query(({ input }) => ({
+      greeting: `Hello ${input.text ?? 'world'}`,
+    })),
+});
+```
+
+Add sub-routers by merging them into `appRouter`.
+
+## Client
+
+Use the generated hooks in Client Components:
+
+```tsx
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@/utils/trpc';
+
+export function Greeting() {
+  const trpc = useTRPC();
+  const result = useQuery(trpc.hello.queryOptions({ text: 'Next.js' }));
+
+  if (result.isLoading) return null;
+  return <p>{result.data?.greeting}</p>;
+}
+```
+
+## Provider composition
+
+Provider registration lives in `src/app-providers.tsx`. Additional CNA extensions (for example TanStack Query) can append providers to the same registry.
+
+## References
+
+- [tRPC Next.js App Router setup](https://trpc.io/docs/client/nextjs/app-router/setup)
+- [TanStack React Query integration](https://trpc.io/docs/client/tanstack-react-query/setup)

--- a/extensions/nextjs-trpc/package.json
+++ b/extensions/nextjs-trpc/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@tanstack/react-query": "^5.101.1",
+    "@trpc/client": "^11.18.0",
+    "@trpc/server": "^11.18.0",
+    "@trpc/tanstack-react-query": "^11.18.0",
+    "superjson": "^2.2.6"
+  }
+}

--- a/templates.json
+++ b/templates.json
@@ -896,6 +896,21 @@
       ]
     },
     {
+      "name": "tRPC for Next.js",
+      "slug": "nextjs-trpc",
+      "description": "Add tRPC v11 with TanStack Query and App Router fetch adapter for end-to-end type-safe APIs without code generation.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/nextjs-trpc",
+      "type": "nextjs",
+      "category": "API",
+      "labels": [
+        "tRPC",
+        "TanStack Query",
+        "TypeScript",
+        "App Router",
+        "API"
+      ]
+    },
+    {
       "name": "next-intl (i18n) for Next.js",
       "slug": "nextjs-i18n",
       "description": "Add internationalization to your Next.js project using next-intl with English and Spanish translations, middleware routing, and type-safe message access.",


### PR DESCRIPTION
## Summary
- Add `extensions/nextjs-trpc/` with tRPC v11, TanStack Query, superjson, and App Router fetch adapter
- Generate server router, client provider/hooks, `/api/trpc/[trpc]` route, and composable `app-providers` registry
- Include example `TrpcHello` client component and TRPC guide docs

Closes #70

## Test plan
- [x] Scaffold `nextjs-starter` + `nextjs-trpc` locally
- [x] `npm run lint:fix`, `npm run type-check`, `npm run build` pass
- [ ] CI matrix green (nextjs-starter job)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Next.js tRPC integration template with App Router support, client/server wiring, and ready-to-use query handling.
  * Included a sample UI component showing a loading, error, and success state for fetching a greeting.
  * Added a new extension entry so the integration is easier to discover.

* **Documentation**
  * Added setup and usage guidance, including an example call pattern and links to further tRPC and TanStack Query resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->