### PR TITLE
fix(nextjs-trpc): address CodeRabbit review from #94

### DIFF
--- a/extensions/nextjs-trpc/[src]/app-providers.tsx.append.template
+++ b/extensions/nextjs-trpc/[src]/app-providers.tsx.append.template
@@ -1,0 +1,4 @@
+
+import { TRPCReactProvider } from '<%= projectImportPath %>utils/trpc';
+
+appProviders.push((children) => <TRPCReactProvider>{children}</TRPCReactProvider>);

--- a/extensions/nextjs-trpc/[src]/app-providers.tsx.template
+++ b/extensions/nextjs-trpc/[src]/app-providers.tsx.template
@@ -2,13 +2,9 @@
 
 import type { ReactNode } from 'react';
 
-import { TRPCReactProvider } from '<%= projectImportPath %>utils/trpc';
-
 type AppProvider = (children: ReactNode) => ReactNode;
 
-export const appProviders: AppProvider[] = [
-  (children) => <TRPCReactProvider>{children}</TRPCReactProvider>,
-];
+export const appProviders: AppProvider[] = [];
 
 export const composeAppProviders = (children: ReactNode) =>
   appProviders.reduceRight((currentChildren, provider) => provider(currentChildren), children);

--- a/extensions/nextjs-trpc/[src]/app/layout.tsx.template
+++ b/extensions/nextjs-trpc/[src]/app/layout.tsx.template
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
 
 import { Providers } from '<%= projectImportPath %>components/providers';
 
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>

--- a/extensions/nextjs-trpc/[src]/components/providers.tsx.template
+++ b/extensions/nextjs-trpc/[src]/components/providers.tsx.template
@@ -1,7 +1,9 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { composeAppProviders } from '<%= projectImportPath %>app-providers';
 
-export function Providers({ children }: Readonly<{ children: React.ReactNode }>) {
+export function Providers({ children }: Readonly<{ children: ReactNode }>) {
   return composeAppProviders(children);
 }

--- a/extensions/nextjs-trpc/[src]/server/trpc.ts
+++ b/extensions/nextjs-trpc/[src]/server/trpc.ts
@@ -7,7 +7,9 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
   };
 };
 
-const t = initTRPC.context<typeof createTRPCContext>().create({
+export type TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>;
+
+const t = initTRPC.context<TRPCContext>().create({
   transformer: superjson,
 });
 

--- a/extensions/nextjs-trpc/[src]/utils/trpc.tsx.template
+++ b/extensions/nextjs-trpc/[src]/utils/trpc.tsx.template
@@ -4,6 +4,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 import superjson from 'superjson';
 
@@ -38,7 +39,7 @@ function getBaseUrl() {
   return 'http://localhost:3000';
 }
 
-export function TRPCReactProvider(props: Readonly<{ children: React.ReactNode }>) {
+export function TRPCReactProvider(props: Readonly<{ children: ReactNode }>) {
   const queryClient = getQueryClient();
 
   const [trpcClient] = useState(() =>

--- a/extensions/nextjs-trpc/package.json
+++ b/extensions/nextjs-trpc/package.json
@@ -4,6 +4,7 @@
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.18.0",
     "@trpc/tanstack-react-query": "^11.18.0",
-    "superjson": "^2.2.6"
+    "superjson": "^2.2.6",
+    "zod": "^3.23.8"
   }
 }

--- a/extensions/nextjs-trpc/package.json
+++ b/extensions/nextjs-trpc/package.json
@@ -5,6 +5,6 @@
     "@trpc/server": "^11.18.0",
     "@trpc/tanstack-react-query": "^11.18.0",
     "superjson": "^2.2.6",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #94 addressing unresolved CodeRabbit review comments.

| CodeRabbit finding | Fix |
|---|---|
| `initTRPC.context` used function type instead of resolved context | Export `TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>` |
| Missing `zod` runtime dependency | Added `zod` to `extensions/nextjs-trpc/package.json` |
| `React.ReactNode` without React namespace import | Import `ReactNode` from `react` in layout/providers/trpc templates |
| Provider registry replacement-based | Split into base `app-providers.tsx.template` + additive `app-providers.tsx.append.template` |

## Test plan

- [ ] Scaffold `nextjs-starter` + `nextjs-trpc` locally and run `npm run type-check`
- [ ] CI template combination matrix passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new data-fetching setup in Next.js apps, including a ready-to-use provider wrapper.
  * Introduced validation support for safer client/server data handling.

* **Bug Fixes**
  * Improved app composition so layouts render correctly even when no extra providers are configured.
  * Updated component typing for more consistent page and provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->