### PR TITLE
fix: modernize turborepo template lint baseline

### DIFF
--- a/templates/turborepo-starter/apps/playground/package.json.template
+++ b/templates/turborepo-starter/apps/playground/package.json.template
@@ -10,8 +10,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",
@@ -23,13 +23,13 @@
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/react": "^6.5.16",
     "@storybook/testing-library": "^0.0.13",
-    "@types/node": "^18.15.3",
-    "@types/react": "^18.0.28",
+    "@types/node": "^26.1.0",
+    "@types/react": "^18.3.31",
     "babel-loader": "^9.1.2",
     "<%= scope%>eslint-config-react": "*",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "react-docgen-typescript-plugin": "^1.0.5",
     "tsconfig": "*",
-    "typescript": "^5.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/templates/turborepo-starter/package/index.js
+++ b/templates/turborepo-starter/package/index.js
@@ -17,10 +17,10 @@ module.exports = function resolvePackage(setup, { appName, usePnpm }) {
       "type-check": "turbo run type-check"
     },
     "devDependencies": {
-      "@changesets/cli": "^2.25.0",
+      "@changesets/cli": "^2.31.0",
       [eslintConfigBaseName]: "0.0.0",
-      "prettier": "^2.7.1",
-      "turbo": "^1.5.5"
+      "prettier": "^3.9.4",
+      "turbo": "^2.10.2"
     },
     "dependencies": {
       "tsup": "^6.2.3"

--- a/templates/turborepo-starter/packages/eslint-config-base/package.json.template
+++ b/templates/turborepo-starter/packages/eslint-config-base/package.json.template
@@ -8,8 +8,8 @@
     "index.js"
   ],
   "dependencies": {
-    "eslint": "^7.23.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-config-turbo": "^0.0.4"
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-config-turbo": "^2.10.2"
   }
 }

--- a/templates/turborepo-starter/packages/eslint-config-next/package.json.template
+++ b/templates/turborepo-starter/packages/eslint-config-next/package.json.template
@@ -8,8 +8,8 @@
     "index.js"
   ],
   "dependencies": {
-    "eslint": "^7.23.0",
+    "eslint": "^9.39.4",
     "<%= scope%>eslint-config-ts": "*",
-    "eslint-config-next": "^12.0.8"
+    "eslint-config-next": "^15.5.4"
   }
 }

--- a/templates/turborepo-starter/packages/eslint-config-next/package.json.template
+++ b/templates/turborepo-starter/packages/eslint-config-next/package.json.template
@@ -10,6 +10,6 @@
   "dependencies": {
     "eslint": "^9.39.4",
     "<%= scope%>eslint-config-ts": "*",
-    "eslint-config-next": "^15.5.4"
+    "eslint-config-next": "^16.2.10"
   }
 }

--- a/templates/turborepo-starter/packages/eslint-config-react/index.js
+++ b/templates/turborepo-starter/packages/eslint-config-react/index.js
@@ -4,4 +4,9 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
   ],
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
 };

--- a/templates/turborepo-starter/packages/eslint-config-react/package.json.template
+++ b/templates/turborepo-starter/packages/eslint-config-react/package.json.template
@@ -9,11 +9,11 @@
   ],
   "dependencies": {
     "<%= scope%>eslint-config-ts": "*",
-    "eslint": "^7.23.0",
+    "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^4.6.2"
+    "eslint-plugin-react-hooks": "^7.1.1"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/templates/turborepo-starter/packages/eslint-config-ts/package.json.template
+++ b/templates/turborepo-starter/packages/eslint-config-ts/package.json.template
@@ -8,11 +8,12 @@
     "index.js"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.39.0",
-    "eslint": "^7.23.0",
+    "@typescript-eslint/eslint-plugin": "^8.62.1",
+    "@typescript-eslint/parser": "^8.62.1",
+    "eslint": "^9.39.4",
     "<%= scope%>eslint-config-base": "*"
   },
   "devDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^5.9.3"
   }
 }

--- a/templates/turborepo-starter/packages/ui/index.tsx
+++ b/templates/turborepo-starter/packages/ui/index.tsx
@@ -1,2 +1,1 @@
-import * as React from "react";
 export * from "./Button";

--- a/templates/turborepo-starter/packages/ui/package.json.template
+++ b/templates/turborepo-starter/packages/ui/package.json.template
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/react": "^18.0.22",
     "<%= scope%>eslint-config-react": "*",
-    "eslint": "^7.32.0",
+    "eslint": "^9.39.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsconfig": "*",

--- a/templates/turborepo-starter/packages/ui/package.json.template
+++ b/templates/turborepo-starter/packages/ui/package.json.template
@@ -21,12 +21,12 @@
     "tsup": "^6.2.3"
   },
   "devDependencies": {
-    "@types/react": "^18.0.22",
+    "@types/react": "^18.3.31",
     "<%= scope%>eslint-config-react": "*",
     "eslint": "^9.39.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tsconfig": "*",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## What
- update turborepo template lint baseline to ESLint 9
- upgrade related eslint config packages to current majors
- remove unused React import in ui package export barrel
- add react version detection to shared react eslint config
- refresh root toolchain versions (turbo, prettier, changesets)

## Why
Fresh turborepo-boilerplate scaffolds were emitting deprecation noise from old lint deps and avoidable lint warnings by default.

Closes #107

## Validation
- template-level diff reviewed
- planned local scaffold validation commands:
  - CI=true npx create-awesome-node-app@latest <path> --template file://.../cna-templates?subdir=templates/turborepo-starter --no-interactive --no-install
  - npm install --no-audit
  - npm run lint
  - npm run type-check
  - npm run build
