### PR TITLE
fix: format react-tailwindcss addon output

### DIFF
--- a/extensions/react-tailwindcss/[src]/components/Button/Button.tsx.template
+++ b/extensions/react-tailwindcss/[src]/components/Button/Button.tsx.template
@@ -7,9 +7,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 
 const Button: React.FC<ButtonProps> = ({ children, loading, className = '', ...rest }) => (
   <button
-    className={
-      ('btn-primary ' + (loading ? 'opacity-70 cursor-wait' : '') + ' ' + className).trim()
-    }
+    className={('btn-primary ' + (loading ? 'opacity-70 cursor-wait' : '') + ' ' + className).trim()}
     disabled={rest.disabled || loading}
     {...rest}
   >

--- a/extensions/react-tailwindcss/tailwind.config.js.template
+++ b/extensions/react-tailwindcss/tailwind.config.js.template
@@ -4,10 +4,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
-  content: [
-    './index.html',
-    '<%= srcDir %>/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', '<%= srcDir %>/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
@@ -21,13 +18,13 @@ module.exports = {
           600: '#1559e6',
           700: '#0f44b4',
           800: '#0d378f',
-          900: '#0c2f75'
-        }
+          900: '#0c2f75',
+        },
       },
       borderRadius: {
-        xl: '1rem'
-      }
-    }
+        xl: '1rem',
+      },
+    },
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
## What
- format react-tailwindcss addon templates to match generated Prettier rules
- inline the Button className expression in Button.tsx.template
- normalize tailwind.config.js.template array/object trailing commas and compact content array

## Why
The documented React + Tailwind + Zustand recipe generated unformatted files that fail npm run lint and then block npm run build when ESLint runs in Vite build.

Closes #108

## Validation
- checked failing lines from audit logs against template sources
- confirmed templates now match the repo Prettier style (singleQuote, trailingComma: all)
