### PR TITLE
fix(ci): remove deprecated baseUrl from template tsconfigs

### DIFF
--- a/templates/astro-starter/tsconfig.json.template
+++ b/templates/astro-starter/tsconfig.json.template
@@ -9,7 +9,6 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -14,7 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }

--- a/templates/remix-starter/package.json
+++ b/templates/remix-starter/package.json
@@ -9,10 +9,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@react-router/node": "^7.6.2",
     "isbot": "^5.1.31",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "@react-router/node": "^7.6.2",
     "react-router": "^7.6.2"
   },
   "devDependencies": {

--- a/templates/remix-starter/package.json
+++ b/templates/remix-starter/package.json
@@ -9,10 +9,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-router/node": "^7.6.2",
     "isbot": "^5.1.31",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "@react-router/node": "^7.6.2",
     "react-router": "^7.6.2"
   },
   "devDependencies": {

--- a/templates/remix-starter/tsconfig.json.template
+++ b/templates/remix-starter/tsconfig.json.template
@@ -11,7 +11,6 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": ".",
     "rootDirs": [".", "./.react-router/types"],
     "paths": {
       "~/*": ["./<%= srcDir %>/*"]

--- a/templates/webextension-react-vite-starter/tsconfig.json.template
+++ b/templates/webextension-react-vite-starter/tsconfig.json.template
@@ -14,7 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"],
       "virtual:reload-on-update-in-background-script": ["./<%= srcDir%>/global.d.ts"],


### PR DESCRIPTION
## What
- remove deprecated `compilerOptions.baseUrl` from template tsconfig files used in CI matrix generation:
  - `templates/astro-starter/tsconfig.json.template`
  - `templates/react-vite-starter/tsconfig.json.template`
  - `templates/remix-starter/tsconfig.json.template`
  - `templates/webextension-react-vite-starter/tsconfig.json.template`
- keep existing path alias mappings intact via `compilerOptions.paths`

## Why
`Test Template and Extension Combinations` can fail on `main` with:

`TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0`

Removing `baseUrl` avoids deprecation-driven failures while preserving alias behavior in these templates.

## Validation
- reproduced failing path from CI logs (`Test Template and Extension Combinations`, remix-starter)
- local scaffold + checks for remix-starter with this branch changes:
  - `npm install`
  - `npm run type-check --if-present`
  - `SKIP_ENV_VALIDATION=true npm run build --if-present`
  - result: pass

Closes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified TypeScript starter configurations by removing an unnecessary default path setting while keeping existing path aliases intact.
  * Reordered dependencies in one starter template for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->