### PR TITLE
fix(ci): update react-i18n extension for TypeScript 6

### DIFF
--- a/extensions/react-i18n/package.json
+++ b/extensions/react-i18n/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "i18next": "^24.2.2",
-    "i18next-browser-languagedetector": "^8.0.3",
-    "i18next-http-backend": "^3.0.2",
-    "react-i18next": "^15.4.0"
+    "i18next": "^26.3.4",
+    "i18next-browser-languagedetector": "^8.2.1",
+    "i18next-http-backend": "^4.0.0",
+    "react-i18next": "^17.0.8"
   }
 }


### PR DESCRIPTION
## What changed
- upgrade react-i18n extension dependencies to TypeScript 6-compatible versions
- update i18next, react-i18next, i18next-browser-languagedetector, and i18next-http-backend

## Why
- main workflow run 28676008732 failed in Test Template and Extension Combinations for react-vite-boilerplate
- the failure was npm ERESOLVE because i18next 24.x has peerOptional typescript ^5 while templates now install typescript ^6.0.3

## Validation
- reproduced the failing combo locally with template react-vite-starter plus these extensions:
  - all-github-setup
  - react-testing-library-with-vitest
  - react-i18n
  - react-xstate
  - react-android-tools
  - react-shadcn
  - react-apollo
- before this change: scaffold failed during devDependencies install with peerOptional typescript ^5 from i18next
- after this change: scaffold/install completed successfully

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several translation-related libraries to newer versions.
  * This should help keep localization features compatible and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->