### PR TITLE
fix(ci): upgrade storybook extension to v10 for Next 16 compatibility

### DIFF
--- a/extensions/storybook/package.json
+++ b/extensions/storybook/package.json
@@ -1,14 +1,15 @@
 {
   "name": "storybook-extension",
   "devDependencies": {
-    "@storybook/addon-essentials": "^8.6.12",
-    "@storybook/addon-interactions": "^8.6.12",
-    "@storybook/addon-links": "^8.6.12",
-    "@storybook/blocks": "^8.6.12",
-    "@storybook/nextjs": "^8.6.12",
-    "@storybook/react": "^8.6.12",
-    "@storybook/test": "^8.6.12",
-    "storybook": "^8.6.12"
+    "@storybook/addon-essentials": "^10.4.6",
+    "@storybook/addon-interactions": "^10.4.6",
+    "@storybook/addon-links": "^10.4.6",
+    "@storybook/blocks": "^10.4.6",
+    "@storybook/nextjs": "^10.4.6",
+    "@storybook/react": "^10.4.6",
+    "@storybook/react-vite": "^10.4.6",
+    "@storybook/test": "^10.4.6",
+    "storybook": "^10.4.6"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## What changed
- upgrade all storybook packages from ^8.6.x to ^10.4.6
- add @storybook/react-vite for react-vite project support

## Why
- nextjs-starter uses next@^16.2.10 but @storybook/nextjs@8.x peers ^13 || ^14 || ^15
- storybook v10 supports next ^14.1.0 || ^15.0.0 || ^16.0.0
- also prepares storybook for proper react-vite framework support

## Validation
- CI failed with ERESOLVE: @storybook/nextjs@8.6.18 incompatible with next@16.2.10
- After upgrade, v10 peer deps include next ^16.0.0

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Storybook toolchain to a newer major version across the app’s development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->