### PR TITLE
fix(ci): ignore .storybook/ in react-vite eslint config

### DIFF
--- a/templates/react-vite-starter/eslint.config.mjs.template
+++ b/templates/react-vite-starter/eslint.config.mjs.template
@@ -28,7 +28,7 @@ export default [
   },
   {
     files: ['**/*.{ts,tsx}'],
-    ignores: ['vite.config.ts', 'vite.config.d.ts', 'electron/**/*'],
+    ignores: ['vite.config.ts', 'vite.config.d.ts', 'electron/**/*', '.storybook/**/*'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',


### PR DESCRIPTION
## What changed
- add .storybook/ to eslint ignores for ts/tsx files in react-vite-starter

## Why
- When storybook extension is added to react-vite-starter, .storybook/main.ts and .storybook/preview.ts get linted with parserOptions.project pointing to tsconfig.json
- tsconfig.json uses project references and doesn't include .storybook/ directly, causing typescript-eslint parsing errors
- .storybook/ files are tool config, not application source code

## Validation
- CI run 28680089594 react-vite-boilerplate failed with: "That TSConfig uses project references and doesn't include .storybook/main.ts directly"
- Adding to ignores prevents these files from being type-checked by ESLint

Closes #127