### PR TITLE
fix(ci): add node types to react-vite-starter tsconfig

### DIFF
--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -14,6 +14,7 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["node"],
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }

--- a/templates/react-vite-starter/tsconfig.node.json
+++ b/templates/react-vite-starter/tsconfig.node.json
@@ -3,7 +3,8 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "commitlint.config.ts"]
 }


### PR DESCRIPTION
## What changed
- add "types": ["node"] to react-vite-starter tsconfig.json.template compilerOptions
- add "types": ["node"] and config file includes to tsconfig.node.json

## Why
- TypeScript 6 requires explicit types for @types/node to resolve Node.js globals
- Extension-added files (commitlint.config.ts, playwright.config.ts, apollo-client.ts) reference process/module globals
- CI fails with TS2591 "Cannot find name process/module"

## Validation
- CI run 28683019850 react-vite-boilerplate: 10x TS2591 errors for process/module
- After fix: node types available for config files and source code

Closes #132