### PR TITLE
fix(ci): fix deprecated tsconfig options in nestjs-starter

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -10,11 +10,10 @@
     "target": "ES2019",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "resolveJsonModule": true
   },
   "exclude": [


### PR DESCRIPTION
## What changed
- remove "baseUrl": "./" (deprecated in TypeScript 6, will stop functioning in TS7)
- change "moduleResolution": "node" to "moduleResolution": "node16" (Node.js-style resolution for CommonJS)

## Why
- TypeScript 6 reports TS5101/TS5107 for deprecated baseUrl and moduleResolution=node
- CI fails with tsc --noEmit exit code 2 in nestjs-boilerplate

## Validation
- CI run 28683019850 nestjs-boilerplate: TS5101 baseUrl, TS5107 moduleResolution=node10
- After fix: clean tsc --noEmit

Closes #133