### PR TITLE
fix(ci): revert storybook extension to v8 for addon compatibility

### DIFF
--- a/extensions/storybook/package.json
+++ b/extensions/storybook/package.json
@@ -1,15 +1,15 @@
 {
   "name": "storybook-extension",
   "devDependencies": {
-    "@storybook/addon-essentials": "^10.4.6",
-    "@storybook/addon-interactions": "^10.4.6",
-    "@storybook/addon-links": "^10.4.6",
-    "@storybook/blocks": "^10.4.6",
-    "@storybook/nextjs": "^10.4.6",
-    "@storybook/react": "^10.4.6",
-    "@storybook/react-vite": "^10.4.6",
-    "@storybook/test": "^10.4.6",
-    "storybook": "^10.4.6"
+    "@storybook/addon-essentials": "^8.6.18",
+    "@storybook/addon-interactions": "^8.6.18",
+    "@storybook/addon-links": "^8.6.18",
+    "@storybook/blocks": "^8.6.18",
+    "@storybook/nextjs": "^8.6.18",
+    "@storybook/react": "^8.6.18",
+    "@storybook/react-vite": "^8.6.18",
+    "@storybook/test": "^8.6.18",
+    "storybook": "^8.6.18"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## What changed
- revert storybook extension package versions from v10 to v8.6.18
- keep @storybook/react-vite dependency (available at v8)

## Why
- storybook v10.4.6 does not exist for all addon packages (addon-essentials, addon-interactions, blocks, test) — only core packages shipped at v10
- @storybook/addon-essentials@^10.4.6 causes npm ETARGET "No matching version found"
- v8.6.18 is the latest stable dist-tag for ALL storybook packages

## Validation
- CI run 28683318944 react-vite-boilerplate: npm ETARGET for @storybook/addon-essentials@^10.4.6
- After revert: all packages resolve to v8.6.18

Follow-up: storybook v10 addon packages need to be published before upgrading