### PR TITLE
fix(ci): use ignoreDeprecations for nestjs-starter tsconfig

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -13,8 +13,9 @@
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,
-    "moduleResolution": "node16",
-    "resolveJsonModule": true
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## What changed
- revert moduleResolution to "node" (CommonJS compatible)
- add "ignoreDeprecations": "6.0" to suppress baseUrl and moduleResolution deprecation errors in TypeScript 6

## Why
- moduleResolution: "node16" requires module: "node16", but NestJS uses module: "commonjs"
- CI fails with TS5110: "Option module must be set to Node16 when moduleResolution is set to Node16"
- Using ignoreDeprecations is the safe approach for NestJS CommonJS projects until migration to ESM

## Validation
- CI run 28683318944 nestjs-boilerplate: TS5110 moduleResolution=node16 requires module=node16
- After fix: clean tsc --noEmit with suppressed deprecation warnings