### PR TITLE
fix(ci): add jest and node types to nestjs-starter tsconfig

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,
+    "types": ["jest", "node"],
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"


### PR DESCRIPTION
## What changed
- add "types": ["jest", "node"] to nestjs-starter tsconfig compilerOptions

## Why
- TypeScript 6 requires explicit types for @types/jest to resolve test globals (describe, it, expect, beforeAll, beforeEach)
- CI fails with TS2593 "Cannot find name describe/jest/it/expect" in spec files
- Also adds node types for process/module globals used in NestJS server code

## Validation
- CI run 28683660912 nestjs-boilerplate: 20+ TS2593 errors for Jest globals
- After fix: test globals resolved via @types/jest