### PR TITLE
fix(ci): remove @storybook/react-vite from storybook extension

### DIFF
--- a/extensions/storybook/package.json
+++ b/extensions/storybook/package.json
@@ -7,7 +7,6 @@
     "@storybook/blocks": "^8.6.18",
     "@storybook/nextjs": "^8.6.18",
     "@storybook/react": "^8.6.18",
-    "@storybook/react-vite": "^8.6.18",
     "@storybook/test": "^8.6.18",
     "storybook": "^8.6.18"
   },


### PR DESCRIPTION
## What changed
- remove @storybook/react-vite dependency from storybook extension

## Why
- @storybook/react-vite@8.6.18 peers vite@"^4.0.0 || ^5.0.0 || ^6.0.0" but react-vite-starter uses vite@^8.1.3
- causes ERESOLVE install failure when storybook is added to react-vite projects
- @storybook/react-vite was added in PR #129; removing it reverts to previous working state (using @storybook/nextjs for both react and nextjs)

## Validation
- CI run 28683660912 react-vite-boilerplate: ERESOLVE for @storybook/react-vite + vite@8.1.3

Follow-up: re-add @storybook/react-vite when it supports vite 8