### PR TITLE
fix(ci): ignore playwright.config.ts in react-vite eslint

### DIFF
--- a/templates/react-vite-starter/eslint.config.mjs.template
+++ b/templates/react-vite-starter/eslint.config.mjs.template
@@ -28,7 +28,7 @@ export default [
   },
   {
     files: ['**/*.{ts,tsx}'],
-    ignores: ['vite.config.ts', 'vite.config.d.ts', 'electron/**/*', '.storybook/**/*'],
+    ignores: ['vite.config.ts', 'vite.config.d.ts', 'electron/**/*', '.storybook/**/*', 'playwright.config.ts'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',


### PR DESCRIPTION
## What changed
- add playwright.config.ts to eslint ignores for ts/tsx files in react-vite-starter

## Why
- When react-playwright extension is added, playwright.config.ts gets parsed by ESLint using parserOptions.project pointing to tsconfig.json
- tsconfig.json uses project references and does not include root config files directly
- Causes Parsing error similar to .storybook/ issue

## Validation
- CI run 28683941775 react-vite-boilerplate: Parsing error on playwright.config.ts
- After fix: playwright.config.ts ignored by ESLint type-aware parsing