### PR TITLE
fix(ci): add rootDir to nestjs-starter tsconfigs

### DIFF
--- a/templates/nestjs-starter/tsconfig.build.json
+++ b/templates/nestjs-starter/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "exclude": [
     "node_modules",
     "dist",

--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -10,6 +10,7 @@
     "target": "ES2019",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": ".",
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## What changed
- add "rootDir": "." to tsconfig.json for type-check compatibility
- add "rootDir": "src" to tsconfig.build.json for correct build output structure

## Why
- TypeScript 6 reports TS5011 when rootDir is not explicitly set
- tsconfig.build.json's common source directory is ./src but rootDir was unset
- CI fails at type-check / build step with "The common source directory of tsconfig.build.json is ./src. The rootDir setting must be explicitly set"

## Validation
- CI run 28683941775 nestjs-boilerplate: TS5011 rootDir error
- After fix: clean tsc --noEmit and nest build