### PR TITLE
fix(ci): ignore vitest.config.ts in react-vite eslint

### DIFF
--- a/templates/react-vite-starter/eslint.config.mjs.template
+++ b/templates/react-vite-starter/eslint.config.mjs.template
@@ -28,7 +28,7 @@ export default [
   },
   {
     files: ['**/*.{ts,tsx}'],
-    ignores: ['vite.config.ts', 'vite.config.d.ts', 'electron/**/*', '.storybook/**/*', 'playwright.config.ts'],
+    ignores: ['vite.config.ts', 'vite.config.d.ts', 'vitest.config.ts', 'electron/**/*', '.storybook/**/*', 'playwright.config.ts'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',


### PR DESCRIPTION
## What changed
- add vitest.config.ts to eslint ignores for ts/tsx files in react-vite-starter

## Why
- When react-testing-library-with-vitest extension is added, vitest.config.ts gets parsed by ESLint using parserOptions.project pointing to tsconfig.json
- tsconfig.json uses project references and does not include the root config file directly
- CI fails with Parsing error on vitest.config.ts

## Validation
- CI run 28684495190 react-vite-boilerplate: Parsing error on vitest.config.ts