### PR TITLE
fix(ci): add better-sqlite3 types for nestjs-drizzle-sqlite extension

### DIFF
--- a/extensions/nestjs-drizzle-sqlite/package.json
+++ b/extensions/nestjs-drizzle-sqlite/package.json
@@ -10,6 +10,7 @@
     "better-sqlite3": "^11.8.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "drizzle-kit": "^0.31.8"
   }
 }

--- a/extensions/nestjs-drizzle-sqlite/src/db/drizzle.provider.ts
+++ b/extensions/nestjs-drizzle-sqlite/src/db/drizzle.provider.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 @Injectable()
 export class DrizzleProvider implements OnModuleInit {
-  db: BetterSQLite3Database;
+  db!: BetterSQLite3Database;
 
   constructor(private readonly configService: ConfigService) {}
 


### PR DESCRIPTION
## What changed
- add @types/better-sqlite3 to nestjs-drizzle-sqlite extension devDependencies
- use definite assignment assertion (!) on DrizzleProvider.db property to satisfy TS strictPropertyInitialization

## Why
- TypeScript 6 reports TS7016 for better-sqlite3 missing declaration file and TS2564 for uninitialized db property when nestjs-drizzle-sqlite extension is installed
- CI run 28684714502 nestjs-boilerplate failed with extensions all-devcontainer + nestjs-drizzle-sqlite + nestjs-serverless

## Validation
- After fix: better-sqlite3 types resolve and db property is accepted as definitely assigned in onModuleInit

Closes #142