### PR TITLE
fix(ci): scope nestjs build tsconfig to src directory

### DIFF
--- a/templates/nestjs-starter/tsconfig.build.json
+++ b/templates/nestjs-starter/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "src",
+    "outDir": "./dist"
   },
+  "include": ["src/**/*"],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
## What changed
- add include: ["src/**/*"] to tsconfig.build.json
- add explicit outDir: "./dist" to tsconfig.build.json compilerOptions

## Why
- After adding rootDir: "src" to tsconfig.build.json, the default include picks up root files like drizzle.config.ts, causing TS6059
- Scoping include to src/**/* keeps build output clean and avoids root config files being compiled under rootDir src

## Validation
- CI run 28684914071 nestjs-boilerplate: TS6059 drizzle.config.ts not under rootDir src
- After fix: only src files compiled for build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration for the NestJS starter so source files are compiled from `src` and output is generated in `dist`.
  * Narrowed the build scope to include only files under `src`, helping keep builds more consistent and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->