### PR TITLE
fix(ci): revert react-vite tsconfig.node.json to vite.config.ts only

### DIFF
--- a/templates/react-vite-starter/tsconfig.node.json
+++ b/templates/react-vite-starter/tsconfig.node.json
@@ -6,5 +6,5 @@
     "allowSyntheticDefaultImports": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "commitlint.config.ts"]
+  "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## What changed
- revert templates/react-vite-starter/tsconfig.node.json include to ["vite.config.ts"]
- keep types: ["node"] in tsconfig.json for Node globals

## Why
- Adding optional config files (vitest.config.ts, playwright.config.ts, commitlint.config.ts) to tsconfig.node.json causes TS6305 project reference errors when extensions are not installed
- Root config files are already ignored by ESLint parserOptions.project scope individually

## Validation
- CI run 28684914071 react-vite-boilerplate: TS6305 Output file playwright.config.d.ts has not been built from source file
- After revert: tsc project references resolve cleanly

Closes #145