### PR TITLE
fix(ci): remove useless try/catch in nestjs-drizzle-postgres asm helper

### DIFF
--- a/extensions/nestjs-drizzle-postgres/src/helpers/asm.ts
+++ b/extensions/nestjs-drizzle-postgres/src/helpers/asm.ts
@@ -14,17 +14,11 @@ export const getSecretsManagerClient = () => {
 
 export const getSecretValue = async (secretName: string) => {
   const client = getSecretsManagerClient();
-  try {
-    const command = new GetSecretValueCommand({
-      SecretId: secretName,
-      // VersionStage defaults to AWSCURRENT if unspecified
-      VersionStage: 'AWSCURRENT',
-    });
-    const response = await client.send(command);
-    return response.SecretString;
-  } catch (error) {
-    // For a list of exceptions thrown, see
-    // https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-    throw error;
-  }
+  const command = new GetSecretValueCommand({
+    SecretId: secretName,
+    // VersionStage defaults to AWSCURRENT if unspecified
+    VersionStage: 'AWSCURRENT',
+  });
+  const response = await client.send(command);
+  return response.SecretString;
 };


### PR DESCRIPTION
## What changed
- remove unnecessary try/catch wrapper that only re-throws the error in src/helpers/asm.ts

## Why
- ESLint rule no-useless-catch reports error in generated projects using nestjs-drizzle-postgres extension
- CI run 28685145841 nestjs-boilerplate: src/helpers/asm.ts line 14:3 "Unnecessary try/catch wrapper"

## Validation
- lint:fix now passes for the generated project