### PR TITLE
fix(ci): add esbuild dependency for react-electron-vite

### DIFF
--- a/extensions/react-electron-vite/package.json
+++ b/extensions/react-electron-vite/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "electron": "^43.0.0",
     "electron-builder": "^26.15.3",
+    "esbuild": "^0.25.4",
     "vite-electron-plugin": "^0.8.2"
   }
 }


### PR DESCRIPTION
## What changed
- add esbuild to react-electron-vite extension devDependencies

## Why
- The custom vite.config.ts sets esbuild options with loader tsx, but esbuild is not a direct dependency
- Vite 8 install fails at build with "Cannot find module esbuild" when react-electron-vite extension is used
- CI run 28685386656 react-vite-boilerplate: build failed with Cannot find module esbuild

## Validation
- After fix, esbuild resolves directly and vite build can load the config