### PR TITLE
fix(ci): align esbuild version with vite 8 peer requirement

### DIFF
--- a/extensions/react-electron-vite/package.json
+++ b/extensions/react-electron-vite/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "electron": "^43.0.0",
     "electron-builder": "^26.15.3",
-    "esbuild": "^0.25.4",
+    "esbuild": "^0.28.0",
     "vite-electron-plugin": "^0.8.2"
   }
 }


### PR DESCRIPTION
## What changed
- bump esbuild devDependency from ^0.25.4 to ^0.28.0

## Why
- vite@8.1.3 has peerOptional esbuild@"^0.27.0 || ^0.28.0"
- esbuild@0.25.x conflicts with vite 8 peer, causing ERESOLVE
- CI run 28685592201 react-vite-boilerplate: peer conflict between esbuild@0.25.12 and vite@8.1.3

## Validation
- esbuild@^0.28.0 satisfies vite 8 peer range