### PR TITLE
fix(ci): disable css minification to avoid semantic-ui lightningcss failures

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -64,6 +64,9 @@ export default defineConfig({
     loader: 'tsx',
     include: '<%= srcDir %>/**/*.{ts,tsx,js,jsx}',
   },
+  build: {
+    cssMinify: false,
+  },
   optimizeDeps: {
     esbuildOptions: {
       loader: {


### PR DESCRIPTION
## What changed
- disable CSS minification in react-vite-starter vite config (`build.cssMinify: false`)

## Why
- Semantic UI CSS contains selectors like `[data-tooltip][data-inverted]:after .header` that lightningcss (Vite 8 default minifier) rejects with "Pseudo-elements... can't be followed by selectors"
- This breaks `vite build` for the react-vite-boilerplate combination that includes `react-semantic-ui` extension
- CI run 28685756675 failed at `[plugin vite:css-post] SyntaxError: [lightningcss minify] Pseudo-elements like '::before/::after' can't be followed...`

## Validation
- Locally scaffolded react-vite-starter + all extensions including react-semantic-ui and confirmed `npm run build` succeeds after setting `cssMinify: false`
- Build outputs assets correctly and PWA generation completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the starter app build configuration so CSS minification is disabled during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->