### PR TITLE
fix(extensions): resolve nestjs-drizzle-sqlite and Storybook failures

### DIFF
--- a/.github/workflows/test-combinations.yml
+++ b/.github/workflows/test-combinations.yml
@@ -62,6 +62,18 @@ jobs:
             return false;
           };
 
+          const hasIncompatibility = (selected, candidate) => {
+            const candidateSlugs = new Set([candidate.slug]);
+            const selectedSlugs = new Set(selected.map(e => e.slug));
+            for (const ext of selected) {
+              const incompatible = ext.incompatibleWith || [];
+              if (incompatible.some(s => candidateSlugs.has(s))) return true;
+              const candidateIncompatible = candidate.incompatibleWith || [];
+              if (candidateIncompatible.some(s => selectedSlugs.has(s))) return true;
+            }
+            return false;
+          };
+
           const randomCombinations = data.templates.map(template => {
             const compatibleExtensions = extensions.filter(ext => {
               const extTypes = Array.isArray(ext.type) ? ext.type : [ext.type];

--- a/extensions/nestjs-drizzle-sqlite/src/db/drizzle.provider.ts
+++ b/extensions/nestjs-drizzle-sqlite/src/db/drizzle.provider.ts
@@ -7,20 +7,30 @@ import path from 'path';
 
 @Injectable()
 export class DrizzleProvider implements OnModuleInit {
-  db!: BetterSQLite3Database;
+  private database!: Database.Database;
+  private _db: BetterSQLite3Database | undefined;
 
   constructor(private readonly configService: ConfigService) {}
 
+  get db(): BetterSQLite3Database {
+    if (!this._db) {
+      throw new Error('DrizzleProvider has not been initialized. Wait for onModuleInit() to complete.');
+    }
+    return this._db;
+  }
+
   async onModuleInit() {
-    this.db = drizzle(this.createDb());
+    this.database = this.createDb();
+    this._db = drizzle(this.database);
     // IMPORTANT: After defining the database schema, run the command "npm run migrate"
     // then uncomment the following line!
     // this.migrateDb();
   }
 
   private createDb() {
-    const sqlite_db_name = this.configService.get<string>('SQLITE_DATABASE_NAME') + '.db';
-    return new Database(sqlite_db_name);
+    const sqliteDbName = this.configService.get<string>('SQLITE_DATABASE_NAME') || 'database';
+    const sqliteDbPath = `${sqliteDbName}.db`;
+    return new Database(sqliteDbPath);
   }
 
   private getMigrationsFolder() {
@@ -30,6 +40,6 @@ export class DrizzleProvider implements OnModuleInit {
 
   private migrateDb() {
     const migrationsFolder = this.getMigrationsFolder();
-    migrate(this.db, { migrationsFolder: migrationsFolder });
+    migrate(this.db, { migrationsFolder });
   }
 }

--- a/extensions/storybook/.npmrc
+++ b/extensions/storybook/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/extensions/storybook/package.json
+++ b/extensions/storybook/package.json
@@ -1,14 +1,14 @@
 {
   "name": "storybook-extension",
   "devDependencies": {
-    "@storybook/addon-essentials": "^10.4.6",
-    "@storybook/addon-interactions": "^10.4.6",
-    "@storybook/addon-links": "^10.4.6",
-    "@storybook/blocks": "^10.4.6",
-    "@storybook/nextjs": "^10.4.6",
-    "@storybook/react": "^10.4.6",
-    "@storybook/test": "^10.4.6",
-    "storybook": "^10.4.6"
+    "@storybook/addon-essentials": "^8.6.18",
+    "@storybook/addon-interactions": "^8.6.18",
+    "@storybook/addon-links": "^8.6.18",
+    "@storybook/blocks": "^8.6.18",
+    "@storybook/nextjs": "^8.6.18",
+    "@storybook/react": "^8.6.18",
+    "@storybook/test": "^8.6.18",
+    "storybook": "^8.6.18"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
Closes #153
Closes #154

- Fixes nestjs-drizzle-sqlite provider TypeScript errors by initializing db in onModuleInit and adding fallbacks for configService.get string values.
- Reverts Storybook from unavailable ^10.4.6 back to ^8.6.18 and adds legacy-peer-deps via extensions/storybook/.npmrc so nextjs-starter + storybook installs and builds with Next.js 16.
- Verified locally: nestjs-starter + nestjs-drizzle-sqlite builds; nextjs-starter + storybook builds.