### PR TITLE
docs: add maintenance runbook for AI and human operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --addons material-
 | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) | System overview, type system, generation flow |
 | [docs/AUTHORING.md](./docs/AUTHORING.md) | File conventions, EJS variables, `package/` system |
 | [docs/TESTING.md](./docs/TESTING.md) | Local testing and CI workflow |
+| [docs/MAINTENANCE_RUNBOOK.md](./docs/MAINTENANCE_RUNBOOK.md) | Operational procedures for maintaining templates, extensions, CI, dependencies, security, and releases |
 | [CONTRIBUTING.md](./CONTRIBUTING.md) | How to add templates and extensions |
 
 ## CI compatibility matrix
@@ -54,6 +55,31 @@ The badges above reflect the CI workflows:
 - **Weekly (Sunday UTC):** full matrix — every template with all compatible extensions
 
 See the [Actions tab](https://github.com/Create-Node-App/cna-templates/actions/workflows/test-combinations.yml) for the latest run results.
+
+## For AI assistants: copy-paste to start a maintenance session
+
+If you are an AI agent beginning work on this repository, paste the following prompt exactly (after reading any prior conversation context the user provides):
+
+```text
+You are maintaining the Create-Node-App ecosystem: the `create-node-app` CLI monorepo and the `cna-templates` template/extension bank.
+
+Follow the maintenance runbook at `docs/MAINTENANCE_RUNBOOK.md` and its companion guides (`docs/MAINTENANCE_TEMPLATES.md`, `docs/MAINTENANCE_DEPENDENCIES.md`, `docs/MAINTENANCE_SECURITY.md`, `docs/MAINTENANCE_CI.md`, `docs/MAINTENANCE_RELEASE.md`).
+
+Always:
+1. Run the pre-flight checklist in `docs/MAINTENANCE_RUNBOOK.md` Section 3 before changing code.
+2. Scope work to one fix per PR with a `Closes #<issue>` link when applicable.
+3. Write commits, PRs, issues, and docs in English.
+4. Validate locally with `file://` URLs before pushing (see `docs/MAINTENANCE_TEMPLATES.md` Section 9).
+5. Run the relevant full CI workflow manually after risky merges and watch it to completion.
+6. Update `knowledge/processes/create-node-app-maintenance.md` in the workspace if you discover a new pattern or decision.
+
+Current known constraints:
+- Storybook extension is pinned to `^8.6.18` with `legacy-peer-deps=true` in `extensions/storybook/.npmrc`; do not upgrade to Storybook v10 without resolving issue #161 first.
+- The `test-combinations.yml` generator uses JS variables `repoDir` and `tplDir` unescaped; never prefix them with a backslash inside the heredoc.
+- `create-node-app` releases use npm Trusted Publishing via OIDC; do not use a manual `NPM_TOKEN`.
+
+If the user only says "continue" or asks "what should I do next", summarize the current CI/issues state and propose the next action.
+```
 
 ## Support
 

--- a/docs/MAINTENANCE_CI.md
+++ b/docs/MAINTENANCE_CI.md
@@ -1,0 +1,187 @@
+# Maintenance: CI and Workflows
+
+> How to diagnose, fix, and extend the CI workflows that validate the `create-node-app` ecosystem.
+>
+> Read after the top-level [MAINTENANCE_RUNBOOK.md](./MAINTENANCE_RUNBOOK.md).
+
+---
+
+## 1. Workflows overview
+
+### `create-node-app`
+
+| Workflow | Purpose |
+|---|---|
+| `test.yml` | Unit and integration tests |
+| `type-check.yml` | TypeScript type checking |
+| `lint.yml` | Linting |
+| `mega-linter.yml` | MegaLinter across the repo |
+| `osv-scanner.yml` | Security scanning |
+| `publish.yml` | Changesets + npm Trusted Publishing |
+| `pr-review.yml` | PR automation |
+
+### `cna-templates`
+
+| Workflow | Purpose |
+|---|---|
+| `test-combinations.yml` | Random + full matrix of template × extension combinations |
+| `smoke-test.yml` | Quick end-to-end smoke tests on PRs |
+
+---
+
+## 2. Reading CI failures
+
+Always start with the failed logs:
+
+```bash
+gh run view <run-id> --repo Create-Node-App/<repo> --log-failed
+```
+
+For long logs, filter:
+
+```bash
+gh run view <run-id> --repo Create-Node-App/<repo> --log-failed | grep -iE "error|fail|cannot|unable"
+```
+
+List recent runs:
+
+```bash
+gh run list --repo Create-Node-App/<repo> --limit 20
+```
+
+---
+
+## 3. Running workflows manually
+
+```bash
+# cna-templates random + full matrix
+gh workflow run "Test Template and Extension Combinations" \
+  --repo Create-Node-App/cna-templates --ref main
+
+# Watch until it finishes
+gh run watch <run-id> --repo Create-Node-App/cna-templates --exit-status
+
+# create-node-app tests
+gh workflow run "Test" --repo Create-Node-App/create-node-app --ref main
+```
+
+Use `--ref <branch>` to test a PR branch before merging.
+
+---
+
+## 4. The `test-combinations.yml` generator
+
+This workflow is the most common source of maintenance work. It has four jobs:
+
+1. `generate-combinations` — builds a JSON matrix of random, non-conflicting combinations.
+2. `test-combinations` — runs the random matrix.
+3. `generate-full-matrix` — builds a JSON matrix of every template with **all** compatible extensions.
+4. `test-full-matrix` — runs the full matrix.
+
+### 4.1 Random matrix logic
+
+For each template:
+
+- Filter compatible extensions by `type`.
+- Group by `category`.
+- Pick one random extension per category.
+- Skip any extension that conflicts with already-selected ones (`incompatibleWith`).
+
+### 4.2 Full matrix logic
+
+For each template:
+
+- Filter compatible extensions by `type`.
+- Add every mutually-compatible extension to a single job per template.
+
+This is the worst-case scenario and catches peer-dependency blowups.
+
+---
+
+## 5. Common workflow failures
+
+### 5.1 `SyntaxError: Identifier has already been declared`
+
+**Cause:** The Node script embedded in the YAML has a duplicate function or variable declaration.
+
+**Fix:** Remove the duplicate in `.github/workflows/test-combinations.yml`.
+
+**Historical fix:** #159 and #160.
+
+### 5.2 Empty `templateUrl` like `file://?subdir=templates/`
+
+**Cause:** Escaped JS template variables (`\${repoDir}`, `\${tplDir}`) are passed as literal strings instead of being interpolated by Node.
+
+**Fix:** Use `${repoDir}` and `${tplDir}` without backslashes. GitHub Actions does not interpolate `${...}`, only `${{ ... }}`, so the JS here-doc receives the raw `${repoDir}` text that Node evaluates correctly.
+
+**Historical fix:** commit `9d95c3f`.
+
+### 5.3 `npm error ETARGET`
+
+See [MAINTENANCE_DEPENDENCIES.md](./MAINTENANCE_DEPENDENCIES.md).
+
+### 5.4 `npm error ERESOLVE`
+
+See [MAINTENANCE_DEPENDENCIES.md](./MAINTENANCE_DEPENDENCIES.md).
+
+### 5.5 Full matrix passes but random fails (or vice versa)
+
+This usually means:
+
+- The random matrix hit an unlucky combination not covered by the all-at-once full matrix.
+- The full matrix selects all extensions, shadowing a per-extension failure.
+
+Re-run the exact combination locally using the failed job's `templateUrl` and `extensions`.
+
+---
+
+## 6. Testing the embedded Node script locally
+
+The `test-combinations.yml` embeds Node code inside `<<EOF` heredocs. Validate the script before pushing:
+
+```bash
+node - <<'PY'
+const fs = require('fs');
+const txt = fs.readFileSync('.github/workflows/test-combinations.yml', 'utf8');
+let idx = 0;
+for (const match of txt.matchAll(/node <<EOF\n([\s\S]*?)\n          EOF/g)) {
+  let code = match[1].replace(/^          /gm, '');
+  // For syntax validation only, turn escaped template literals back into real ones
+  code = code.replace(/\\\`/g, '`').replace(/\\\$/g, '$');
+  try {
+    new Function(code);
+    console.log(`Block ${idx}: OK`);
+  } catch (e) {
+    console.error(`Block ${idx}: SYNTAX ERROR — ${e.message}`);
+    process.exit(1);
+  }
+  idx++;
+}
+PY
+```
+
+Run this from the `cna-templates` root.
+
+---
+
+## 7. Modifying a workflow safely
+
+1. Make the change in a branch.
+2. Run the syntax validator above.
+3. Push and open a PR.
+4. Run the workflow manually on the branch if possible:
+   ```bash
+   gh workflow run "Test Template and Extension Combinations" \
+     --repo Create-Node-App/cna-templates --ref <branch>
+   ```
+5. Merge only after the manual run succeeds.
+
+---
+
+## 8. Checklist
+
+- [ ] Embedded Node scripts pass local syntax validation.
+- [ ] Workflow YAML is valid (use `cat` + visual check or a YAML linter).
+- [ ] Manual workflow run on the branch passes.
+- [ ] The full matrix is green for risky changes.
+- [ ] Changes do not introduce new secret exposure or permissions escalation.

--- a/docs/MAINTENANCE_DEPENDENCIES.md
+++ b/docs/MAINTENANCE_DEPENDENCIES.md
@@ -1,0 +1,159 @@
+# Maintenance: Dependencies
+
+> How to update, investigate, and resolve dependency conflicts in templates and extensions.
+>
+> Read after the top-level [MAINTENANCE_RUNBOOK.md](./MAINTENANCE_RUNBOOK.md).
+
+---
+
+## 1. Investigating a dependency
+
+Before bumping a version, verify that it exists and that its peer requirements are compatible.
+
+```bash
+# Does a specific version exist?
+npm view <pkg>@<version>
+
+# List recent versions
+npm view <pkg> versions --json | tail -n 20
+
+# Check peer dependencies
+npm view <pkg>@<version> peerDependencies
+
+# Check the whole dependency tree
+npm view <pkg>@<version> dependencies
+```
+
+Example:
+
+```bash
+npm view storybook@10.4.6
+npm view @storybook/addon-essentials versions --json | tail -n 20
+npm view @storybook/nextjs@8.6.18 peerDependencies
+```
+
+If a version is missing, `npm view` returns a 404. That immediately tells you that the range in `package.json` is invalid.
+
+---
+
+## 2. Dependency resolution failures
+
+### 2.1 `npm error ETARGET`
+
+**Meaning:** The requested version does not exist on the registry.
+
+**Common cause:** A template or extension pins a version that has not been published for every package in a monorepo.
+
+**Fix:**
+
+1. Verify which package in the monorepo lacks the version.
+2. Either:
+   - Drop the package if it is no longer needed in the new major line.
+   - Pin to the latest common version across all related packages.
+   - Wait/research the new addon/package name in the new major line.
+
+**Case study:** Storybook `^10.4.6` exists for `storybook`, `@storybook/nextjs`, `@storybook/react`, and `@storybook/addon-links`, but **not** for `@storybook/addon-essentials`, `@storybook/addon-interactions`, `@storybook/blocks`, or `@storybook/test`. The immediate fix was to revert to `^8.6.18`. The follow-up is tracked in issue #161.
+
+### 2.2 `npm error ERESOLVE`
+
+**Meaning:** npm cannot satisfy the dependency tree, usually because of a peer-dependency conflict.
+
+**Common cause:** Two packages require different major versions of the same peer.
+
+**Fix strategies (in order of preference):**
+
+1. **Update both sides** to a mutually compatible version. This is the cleanest fix.
+2. **Downgrade the more aggressive requirement** if the newer major is not strictly needed.
+3. **Add `.npmrc` with `legacy-peer-deps=true`** if the packages are known to work together despite the declared peer range. Several extensions already do this (see `MAINTENANCE_TEMPLATES.md`).
+4. **Mark extensions as incompatible** if they truly cannot coexist.
+
+**Case study:** `@storybook/nextjs@8.6.18` declares `peer next@"^13.5.0 || ^14.0.0 || ^15.0.0"`, but `nextjs-starter` uses Next 16. Keeping Storybook 8 and adding `.npmrc` with `legacy-peer-deps=true` is the current workaround.
+
+### 2.3 Peer dependency warnings that turn into errors
+
+In newer npm versions, peer conflicts can fail installs even when the rest of the tree resolves. Treat peer conflicts as errors if CI breaks.
+
+---
+
+## 3. Updating dependencies
+
+### 3.1 In an extension
+
+1. Edit `extensions/<slug>/package.json`.
+2. Use conservative ranges: `^x.y.z`.
+3. Avoid major-version bumps unless you have validated the breaking changes.
+4. Re-scaffold the extension with each compatible template and run validation.
+
+### 3.2 In a template
+
+Templates usually generate `package.json` via `package/index.js`. Update the versions there or in `dependencies.js`/`devDependencies.js`.
+
+### 3.3 Major updates
+
+A major dependency update is high-risk. For each major:
+
+1. Read the changelog or migration guide.
+2. Check peer dependency requirements.
+3. Test with the full matrix of the affected template.
+4. If breaking changes affect generated code, update template `.template` files or extension files.
+
+---
+
+## 4. Lockfiles
+
+Generated projects do **not** commit lockfiles in this repo, but the validation relies on fresh `npm install`. If a transitive dependency starts breaking installs, consider:
+
+- Pinning the transitive dependency in the extension `package.json`.
+- Using `overrides` in `create-node-app` core (see [MAINTENANCE_SECURITY.md](./MAINTENANCE_SECURITY.md)).
+
+Generated projects will receive whatever the registry returns at install time, so try to avoid relying on transient registry states.
+
+---
+
+## 5. Dependabot PRs
+
+### 5.1 Reviewing
+
+```bash
+gh pr list --repo Create-Node-App/create-node-app --author dependabot --state open
+gh pr view <pr> --repo Create-Node-App/create-node-app
+```
+
+### 5.2 Rebasing if conflicted
+
+```bash
+gh pr comment <pr> --repo Create-Node-App/create-node-app --body "@dependabot rebase"
+```
+
+### 5.3 Merging
+
+Only merge if CI passes. Security-related bumps take priority. If a Dependabot PR fails CI, treat it as a bug fix: reproduce, adjust the dependency range or lockfile, and push to the same PR rather than opening a duplicate.
+
+---
+
+## 6. Tools for complex resolution
+
+```bash
+# Inspect why a version was chosen
+npm ls <pkg>
+
+# Show outdated packages in a generated project
+npm outdated
+
+# Install with maximum logs
+npm install --loglevel verbose
+
+# Force legacy peer resolution (local sanity check)
+npm install --legacy-peer-deps
+```
+
+---
+
+## 7. Checklist
+
+- [ ] The target version exists for every related package in the monorepo.
+- [ ] Peer dependencies are satisfied or explicitly worked around.
+- [ ] The change is scoped to the affected template/extension.
+- [ ] Local validation passes.
+- [ ] Full matrix passes for affected templates.
+- [ ] If security-related, the CVE is actually addressed by the bump.

--- a/docs/MAINTENANCE_RELEASE.md
+++ b/docs/MAINTENANCE_RELEASE.md
@@ -1,0 +1,133 @@
+# Maintenance: Release and Publishing
+
+> How to manage releases, changesets, and npm Trusted Publishing for `create-node-app`.
+>
+> Read after the top-level [MAINTENANCE_RUNBOOK.md](./MAINTENANCE_RUNBOOK.md).
+
+---
+
+## 1. Release model
+
+`create-node-app` is a Changesets-powered monorepo. Releases happen automatically via GitHub Actions.
+
+- Developers add `.changeset/*.md` files with their PRs.
+- The `Release` workflow opens a "Version Packages" PR when changesets exist.
+- Once the Version Packages PR is merged, the workflow publishes to npm.
+
+No manual `npm publish` should be run from a local machine.
+
+---
+
+## 2. Adding a changeset
+
+When a PR modifies a publishable package, add a changeset:
+
+```bash
+npx changeset
+```
+
+Follow the prompts. This creates a file like `.changeset/silly-bears-jump.md`:
+
+```md
+---
+"create-awesome-node-app": patch
+"@create-node-app/core": patch
+---
+
+Fix dependency resolution edge case.
+```
+
+Commit this file as part of the PR.
+
+---
+
+## 3. Publishing requirements
+
+The `publish.yml` workflow uses npm **Trusted Publishing** via OIDC. Requirements:
+
+1. Every publishable `package.json` must have a valid `repository.url`.
+2. The npm CLI in CI must be at least `11.5.1`:
+   ```yaml
+   - run: npm install -g npm@^11.5.1
+   ```
+3. The workflow job must request `id-token: write` permission.
+4. The GitHub environment `npm-publish` must be configured in npmjs.org with the correct publisher identity.
+
+No `NPM_TOKEN` secret is required; the npm CLI auto-detects the OIDC token.
+
+---
+
+## 4. Troubleshooting release failures
+
+### 4.1 "provenance requirements not met" or publish rejected
+
+Check:
+
+- `repository.url` is present and points to the correct GitHub repo.
+- The workflow is running with `id-token: write`.
+- The npm environment in npmjs.org is trusted for this repository.
+- The npm CLI version in CI is `>= 11.5.1`.
+
+### 4.2 Changeset PR not created
+
+Check:
+
+- The PR included a `.changeset/*.md` file.
+- The `release-pr` job in `publish.yml` has `contents: write` and `pull-requests: write` permissions.
+- There are no open changesets already.
+
+### 4.3 Version Packages PR merge fails
+
+If the Version Packages PR fails CI after being auto-generated, fix `main` first, then have Changesets regenerate the PR.
+
+---
+
+## 5. Verifying a release
+
+### 5.1 npm registry
+
+```bash
+npm view create-awesome-node-app@latest version
+npm view @create-node-app/core@latest version
+```
+
+### 5.2 Provenance
+
+Check that the published package has provenance attestation:
+
+```bash
+npm view create-awesome-node-app@latest --json | jq '.dist'
+```
+
+Look for provenance metadata or verify directly in the npmjs package page.
+
+### 5.3 Smoke test
+
+```bash
+npx create-awesome-node-app@latest --help
+```
+
+If all packages were published correctly, the latest CLI starts without errors.
+
+---
+
+## 6. When to release
+
+| Change | Release needed? |
+|---|---|
+| Docs only | No |
+| Template/extension in `cna-templates` | No (templates are fetched from GitHub, not npm) |
+| Fix in `create-node-app` CLI package | Yes, add changeset |
+| Fix in `@create-node-app/*` package | Yes, add changeset |
+| Security fix in CLI dependency | Yes, add changeset and release quickly |
+
+---
+
+## 7. Checklist
+
+- [ ] A changeset was added for every publishable package change.
+- [ ] `repository.url` is present and correct in all publishable `package.json` files.
+- [ ] The Version Packages PR passed CI before merge.
+- [ ] The publish workflow completed successfully.
+- [ ] New versions appear on npm and `npx create-awesome-node-app@latest` works.
+- [ ] No `NPM_TOKEN` or personal npm token was used.

--- a/docs/MAINTENANCE_RUNBOOK.md
+++ b/docs/MAINTENANCE_RUNBOOK.md
@@ -1,0 +1,197 @@
+# Maintenance Runbook
+
+> Single source of truth for operating, extending, and fixing the `create-node-app` ecosystem.
+>
+> Scope: [`Create-Node-App/create-node-app`](https://github.com/Create-Node-App/create-node-app) (CLI + monorepo) and [`Create-Node-App/cna-templates`](https://github.com/Create-Node-App/cna-templates) (template and extension bank).
+
+---
+
+## 1. Why this runbook exists
+
+The project is two repositories that must stay in sync:
+
+- `create-node-app` — the CLI scaffolding tool, published to npm.
+- `cna-templates` — the template and extension bank consumed by the CLI.
+
+Both have automated CI, automated releases, and a large surface area of dependencies. A change in one repo (a new Storybook version, a peer-dependency change in an extension, a Node requirement bump) can break the full matrix in the other. This runbook makes that work repeatable and traceable.
+
+---
+
+## 2. Operating constraints
+
+Read these before any change:
+
+- **One fix per PR.** If two issues are unrelated, open two PRs.
+- **Link issues.** PR bodies must include `Closes #<issue>` when applicable.
+- **English for all artifacts.** Commits, PRs, issues, docs, and comments are written in English.
+- **Do not commit directly to `main`.** Always open a PR and let CI pass before merging.
+- **Do not leave CI red on `main`.** If a merge breaks `main`, treat it as the next P0 fix.
+- **Prefer minimal changes.** Do not refactor unrelated code while fixing a bug.
+- **Document decisions.** If a choice is non-obvious (e.g., pinning Storybook to v8, using `.npmrc` with `legacy-peer-deps`, or adding `incompatibleWith`), document the rationale in the PR and, if recurrent, in this runbook.
+
+---
+
+## 3. Pre-flight checklist for every session
+
+Before writing code, run through this list. It is designed to be executed by a human or an AI agent.
+
+```text
+1. Read AGENTS.md in the target repository.
+2. Read knowledge/processes/create-node-app-maintenance.md in the workspace (AI mirror).
+3. Review open issues:
+   gh issue list --repo Create-Node-App/create-node-app --state open --limit 20
+   gh issue list --repo Create-Node-App/cna-templates --state open --limit 20
+4. Review recent failed CI runs:
+   gh run list --repo Create-Node-App/create-node-app --limit 10
+   gh run list --repo Create-Node-App/cna-templates --limit 10
+5. Identify whether the task is:
+   a) Bug fix (CI/templates/extensions broken)
+   b) Dependency update (security, compatibility, features)
+   c) New template or extension
+   d) Security hardening
+   e) Release/maintenance task
+   f) Research/spike
+6. Route to the right section of this runbook.
+```
+
+---
+
+## 4. Decision tree
+
+Use this to decide which procedure to follow:
+
+```text
+CI is red
+├── Failure is in .github/workflows/test-combinations.yml
+│   └── Read MAINTENANCE_CI.md
+├── Failure is dependency resolution (ERESOLVE, ETARGET, peer conflict)
+│   └── Read MAINTENANCE_DEPENDENCIES.md
+├── Failure is TypeScript / lint / build in a generated project
+│   └── Read MAINTENANCE_TEMPLATES.md
+└── Failure is in create-node-app core workflows (test, lint, type-check, publish)
+    └── Read MAINTENANCE_RELEASE.md
+
+Security alert received
+└── Read MAINTENANCE_SECURITY.md
+
+New template/extension requested
+└── Read MAINTENANCE_TEMPLATES.md
+
+Need to publish a release
+└── Read MAINTENANCE_RELEASE.md
+```
+
+---
+
+## 5. Generic workflow
+
+Every task should follow these phases:
+
+### 5.1 Discovery
+
+- Reproduce the failure locally when possible.
+- Collect exact error messages, CI run IDs, and package versions.
+- Check whether the issue is a regression (recent PR) or an external change (new dependency release).
+
+### 5.2 Plan
+
+- Decide the fix strategy.
+- Identify affected templates/extensions and the CI matrix.
+- Estimate risk. If the change is high-risk, run the full matrix manually before merging.
+
+### 5.3 Implement
+
+- Create a feature/fix branch.
+- Make the smallest change that resolves the issue.
+- Add or update tests/docs as needed.
+
+### 5.4 Validate locally
+
+- For `cna-templates`: scaffold the affected template + extensions with `file://` URLs and run the full validation command.
+- For `create-node-app`: run `npm run test:all`, `npm run lint`, and `npm run build`.
+
+### 5.5 Open PR
+
+- Use a descriptive title.
+- Include `Closes #<issue>` and a clear description of the change, validation performed, and risks.
+- Ensure CI passes on the PR branch.
+
+### 5.6 Merge and monitor
+
+- Merge with squash or merge commit as appropriate.
+- Watch `main` CI after merge.
+- If `main` fails, start a hotfix immediately.
+
+### 5.7 Sync knowledge
+
+- If a new pattern, decision, or shortcut was learned, update `knowledge/processes/create-node-app-maintenance.md` and/or this runbook.
+
+---
+
+## 6. Repositories at a glance
+
+| Repo | What it is | Critical files | Critical CI |
+|---|---|---|---|
+| `create-node-app` | CLI + monorepo | `packages/*/package.json`, `.changeset/config.json`, `.github/workflows/publish.yml` | `test.yml`, `type-check.yml`, `publish.yml`, `mega-linter.yml` |
+| `cna-templates` | Template/extension bank | `templates.json`, `templates.schema.json`, `templates/`, `extensions/`, `.github/workflows/test-combinations.yml` | `test-combinations.yml`, `smoke-test.yml` |
+
+---
+
+## 7. Quick reference: most common commands
+
+```bash
+# --- Scaffold locally from cna-templates ---
+REPO=/absolute/path/to/cna-templates
+CI=true npx create-awesome-node-app@latest my-app \
+  -t "file://$REPO?subdir=templates/<slug>" \
+  --addons "file://$REPO?subdir=extensions/<ext1>" \
+         "file://$REPO?subdir=extensions/<ext2>"
+
+cd my-app
+npm install
+npm run format --if-present
+npm run lint:fix --if-present
+npm run lint --if-present
+npm run type-check --if-present
+SKIP_ENV_VALIDATION=true npm run build --if-present
+
+# --- Inspect CI failures ---
+gh run view <run-id> --repo Create-Node-App/<repo> --log-failed
+
+# --- Run cna-templates CI manually ---
+gh workflow run "Test Template and Extension Combinations" \
+  --repo Create-Node-App/cna-templates --ref main
+gh run watch <run-id> --repo Create-Node-App/cna-templates --exit-status
+
+# --- Inspect package versions ---
+npm view <pkg>@<version>
+npm view <pkg> versions --json | tail -n 20
+
+# --- create-node-app monorepo ---
+npm run build
+npm run test:all
+npm run lint
+```
+
+---
+
+## 8. Related documentation
+
+| File | Use |
+|---|---|
+| [docs/ARCHITECTURE.md](./ARCHITECTURE.md) | How templates and extensions are composed |
+| [docs/AUTHORING.md](./AUTHORING.md) | File conventions, EJS, `package/index.js`, `customOptions` |
+| [docs/TESTING.md](./TESTING.md) | Local test commands |
+| [docs/MAINTENANCE_TEMPLATES.md](./MAINTENANCE_TEMPLATES.md) | Working with templates and extensions |
+| [docs/MAINTENANCE_DEPENDENCIES.md](./MAINTENANCE_DEPENDENCIES.md) | Updating and resolving dependencies |
+| [docs/MAINTENANCE_SECURITY.md](./MAINTENANCE_SECURITY.md) | Security alerts, audits, Dependabot |
+| [docs/MAINTENANCE_CI.md](./MAINTENANCE_CI.md) | CI workflows, troubleshooting, YAML/JS scripts |
+| [docs/MAINTENANCE_RELEASE.md](./MAINTENANCE_RELEASE.md) | Changesets, npm Trusted Publishing, releases |
+
+---
+
+## 9. Runbook changelog
+
+| Date | Change | PR |
+|---|---|---|
+| 2026-07-05 | Initial runbook | TBD |

--- a/docs/MAINTENANCE_SECURITY.md
+++ b/docs/MAINTENANCE_SECURITY.md
@@ -1,0 +1,158 @@
+# Maintenance: Security
+
+> How to handle security alerts, audits, and hardening in the `create-node-app` ecosystem.
+>
+> Read after the top-level [MAINTENANCE_RUNBOOK.md](./MAINTENANCE_RUNBOOK.md).
+
+---
+
+## 1. Sources of alerts
+
+There are three main channels:
+
+1. **GitHub Dependabot alerts** — vulnerabilities in direct and transitive dependencies.
+2. **OSV-Scanner CI** — runs in `create-node-app` via `.github/workflows/osv-scanner.yml`.
+3. **CodeQL alerts** — code scanning alerts in `create-node-app`.
+
+Check all three when doing security work:
+
+```bash
+# Dependabot alerts
+gh api repos/Create-Node-App/create-node-app/dependabot/alerts --jq '.[] | {number, severity, package: .dependency.package.name, title}' | head -n 20
+gh api repos/Create-Node-App/cna-templates/dependabot/alerts --jq '.[] | {number, severity, package: .dependency.package.name, title}' | head -n 20
+
+# CodeQL
+gh code-scanning alerts list --repo Create-Node-App/create-node-app --state open
+gh code-scanning alerts list --repo Create-Node-App/cna-templates --state open
+```
+
+---
+
+## 2. Triage
+
+| Severity | Action |
+|---|---|
+| Critical / High in CLI code path | P0 — fix immediately and release |
+| High in transitive dependency of a template | P1 — fix within the sprint |
+| Moderate / Low | Batch with other maintenance |
+| Informational only | Document and close if not actionable |
+
+Questions to ask:
+
+- Is the vulnerable dependency in the **CLI execution path** or only in generated projects?
+- Can we bump the dependency without breaking the template/extension?
+- Is the fix already available upstream?
+- Can we mitigate with `overrides` while waiting for upstream?
+
+---
+
+## 3. Fixing in `create-node-app`
+
+The CLI monorepo uses pnpm. Root-level overrides can pin transitive dependencies across all packages.
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "esbuild": "^0.28.0",
+      "picomatch": "^4.0.2"
+    }
+  }
+}
+```
+
+Then run:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run test:all
+pnpm run lint
+```
+
+**Case study:** PR #165 "enforce secure esbuild and picomatch versions via overrides" used this exact pattern.
+
+---
+
+## 4. Fixing in `cna-templates`
+
+Templates/extensions do not have committed lockfiles, so the fix must be in `package.json` ranges or `overrides`.
+
+### 4.1 Direct dependency bump
+
+If the vulnerable package is a direct dependency of an extension, bump it in the extension's `package.json`.
+
+### 4.2 Transitive dependency override
+
+If the vulnerable package is transitive, add an `overrides` field in the relevant extension `package.json`:
+
+```json
+{
+  "devDependencies": { ... },
+  "overrides": {
+    "some-vulnerable-pkg": "^x.y.z"
+  }
+}
+```
+
+### 4.3 Cannot fix quickly
+
+If no fixed version exists or the bump is breaking, open a tracking issue and document:
+
+- The CVE or advisory ID.
+- Why it cannot be fixed yet.
+- The planned remediation date.
+
+---
+
+## 5. Running audits locally
+
+```bash
+# In create-node-app
+pnpm audit
+
+# In a generated project
+npm audit
+
+# OSV scanner (requires osv-scanner CLI)
+osv-scanner -r .
+```
+
+---
+
+## 6. CodeQL fixes
+
+CodeQL alerts often relate to:
+
+- Unsafe shell command construction from environment variables or user input.
+- Injection via template strings in CLI code.
+
+### General fix pattern
+
+- Validate and sanitize inputs before passing them to `exec`, `spawn`, or shell templates.
+- Prefer structured arguments (`execFile`, `spawn` with array) over string shell commands.
+- Avoid interpolating user-controlled values directly into commands.
+
+If an alert is a false positive, dismiss it with a comment explaining why.
+
+---
+
+## 7. Validation
+
+After any security change:
+
+1. Run the relevant audit command until the alert is gone or mitigated.
+2. Run the normal CI checks (`test:all`, `lint`, `build`).
+3. For `cna-templates`: scaffold the affected template + extensions and validate.
+4. For `create-node-app`: run `npm run test:all` and the full workflow if possible.
+
+---
+
+## 8. Checklist
+
+- [ ] Alert has been triaged and prioritized.
+- [ ] Fix is minimal and scoped.
+- [ ] Audit no longer reports the vulnerability (or it is documented as unfixable).
+- [ ] CI passes.
+- [ ] Generated projects still install, lint, type-check, and build.
+- [ ] A changeset is added if the fix affects a published package.

--- a/docs/MAINTENANCE_TEMPLATES.md
+++ b/docs/MAINTENANCE_TEMPLATES.md
@@ -1,0 +1,291 @@
+# Maintenance: Templates and Extensions
+
+> How to inspect, fix, add, and update templates and extensions in `cna-templates`.
+>
+> Read after the top-level [MAINTENANCE_RUNBOOK.md](./MAINTENANCE_RUNBOOK.md).
+
+---
+
+## 1. Core concepts
+
+These are defined in `AGENTS.md` and `docs/ARCHITECTURE.md`; the critical points are repeated here because they drive almost every maintenance decision.
+
+### 1.1 Registry
+
+- `templates.json` is the single registry of templates, extensions, and categories.
+- `templates.schema.json` validates the registry.
+- Every template/extension needs: `name`, `slug`, `description`, `url`, `type`, `category`, `labels`.
+- Extensions may also have `incompatibleWith` to declare mutually exclusive extensions.
+
+### 1.2 Type system
+
+- A template has **one** `type` string.
+- An extension has a `type` string **or array** of strings.
+- An extension is compatible with a template when `template.type` is in `[ext.type].flat()`.
+
+### 1.3 File conventions
+
+| Convention | Behavior |
+|---|---|
+| `package/index.js` | Exports a function that returns the generated `package.json`. Most templates use this. |
+| `package/dependencies.js` / `devDependencies.js` | Optional helpers imported by `index.js`. |
+| `*.template` | Processed with EJS; output filename strips `.template`. |
+| `*.append` | Content is appended to the matching file in the project. |
+| `*.if-pnpm` | Only included when the user selects pnpm. |
+| `[name]/` directory | Renamed to the value of the `name` custom option. |
+
+### 1.4 EJS variables
+
+Common variables available in `.template` files:
+
+| Variable | Source |
+|---|---|
+| `<%= projectName %>` | User input or `--set projectName=...` |
+| `<%= srcDir %>` | `cna.config.json` custom option |
+| `<%= projectImportPath %>` | `cna.config.json` custom option |
+| `<%= scope %>` | `cna.config.json` custom option (monorepo) |
+| `<%= installCommand %>` | CLI context |
+| `<%= runCommand %>` | CLI context |
+
+### 1.5 Generation order
+
+1. Resolve template + extension URLs from `templates.json`.
+2. Copy template files.
+3. Process `.template`, `.append`, `.if-pnpm` files.
+4. Rename `[bracket]/` directories based on `customOptions`.
+5. Generate `package.json` from `package/index.js` (or static `package.json`).
+6. Merge extension files and dependencies on top.
+7. Run install and post-generation scripts.
+
+---
+
+## 2. How to inspect an existing template
+
+```bash
+cd repos/github.com/Create-Node-App/cna-templates
+
+# List templates
+ls templates/
+
+# Read the registry entry
+grep -A 15 '"slug": "nestjs-boilerplate"' templates.json
+
+# Read the package generator
+cat templates/nestjs-starter/package/index.js
+
+# Read custom options
+cat templates/nestjs-starter/cna.config.json
+```
+
+Key questions:
+
+- What `type` does it have?
+- What `customOptions` does it define?
+- What scripts does `package/index.js` generate?
+- Are there `[bracket]/` directories that depend on custom options?
+
+---
+
+## 3. How to inspect an existing extension
+
+```bash
+# List extensions
+ls extensions/
+
+# Read the registry entry
+grep -A 15 '"slug": "storybook"' templates.json
+
+# Read dependencies and scripts
+cat extensions/storybook/package.json
+
+# Read files it injects
+ls -la extensions/storybook
+```
+
+Key questions:
+
+- Which `type`s is it compatible with?
+- Does it inject a `.npmrc`? (See [dependency resolution](./MAINTENANCE_DEPENDENCIES.md).)
+- Does it have `.template` files needing EJS variables?
+- Does it have `.append` files that modify existing template files?
+
+---
+
+## 4. Fixing TypeScript / lint / build errors in generated projects
+
+When a generated project fails `type-check`, `lint`, or `build`, the cause is usually in the template or an extension.
+
+### 4.1 Reproduce locally
+
+```bash
+REPO=/absolute/path/to/cna-templates
+CI=true npx create-awesome-node-app@latest my-app \
+  -t "file://$REPO?subdir=templates/<slug>" \
+  --addons "file://$REPO?subdir=extensions/<ext1>"
+
+cd my-app
+npm install
+npm run lint
+npm run type-check
+SKIP_ENV_VALIDATION=true npm run build
+```
+
+### 4.2 Isolate the offending extension
+
+Remove extensions one at a time until the project passes. Then fix the last removed extension.
+
+### 4.3 Common fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Property 'x' has no initializer` | Class property not assigned in constructor under strict mode. | Initialize in lifecycle hook or use a getter with runtime guard. |
+| `Argument of type 'string \| undefined'` | `configService.get('VAR')` may return `undefined`. | Add a fallback: `configService.get('VAR') \|\| 'default'`. |
+| `Cannot find module` | Missing dependency or wrong peer dependency range. | Update the extension `package.json`. |
+| ESLint flat config parser error | Parser not applied to `.ts`/`.tsx`. | Check `eslint.config.mjs` template. |
+| `next build` peer conflict | Storybook/other addon does not support current Next major. | Update addon OR pin Next OR use `.npmrc` with `legacy-peer-deps`. |
+
+### 4.4 Case studies in this repo
+
+- **#153** — `nestjs-drizzle-sqlite` provider had an uninitialized `db` property and implicit string types. Fixed by initializing in `onModuleInit` and adding string fallbacks.
+- **#154** — Storybook 8 peer-required Next `^13\|\|14\|\|15`, but `nextjs-starter` uses Next 16. Fixed by keeping Storybook 8 and adding `legacy-peer-deps=true` in `extensions/storybook/.npmrc`.
+
+---
+
+## 5. Adding or modifying a template
+
+### 5.1 Adding a template
+
+1. Create `templates/<directory>/`.
+2. Add `package/index.js` (and optionally `dependencies.js`/`devDependencies.js`).
+3. Add source files and `.template` files.
+4. Add `cna.config.json` with `customOptions` if interactive prompts are needed.
+5. Add an entry to `templates.json` under `templates`.
+6. Ensure the entry point matches the directory structure.
+7. Run local validation against the new template.
+8. Run the full matrix after merge.
+
+### 5.2 Directory naming caveat
+
+The directory name in `templates/` and the slug in `templates.json` may differ. For example, `nestjs-boilerplate` (slug) lives in `templates/nestjs-starter` (directory). The CLI resolves via `url`, not slug. When generating locally with `file://`, use the directory name:
+
+```bash
+-t "file://$REPO?subdir=templates/nestjs-starter"
+```
+
+### 5.3 Modifying a template
+
+1. Re-scaffold the template with a representative set of extensions.
+2. Apply the change.
+3. Validate lint/type-check/build.
+4. Re-scaffold with **all** compatible extensions (full matrix worst case) to detect conflicts.
+
+---
+
+## 6. Adding or modifying an extension
+
+### 6.1 Adding an extension
+
+1. Create `extensions/<slug>/`.
+2. Add a `package.json` with dependencies and scripts to merge.
+3. Add files, templates, appends, or `.npmrc` as needed.
+4. Add the extension to `templates.json` under `extensions`.
+5. Set `type` to match compatible template types.
+6. Set `category` to avoid selecting multiple extensions from the same category in random CI.
+7. Define `incompatibleWith` if it cannot coexist with other extensions.
+8. Validate locally with **each** compatible template.
+9. Validate the full matrix after merge.
+
+### 6.2 Modifying an extension
+
+1. Identify all templates compatible with the extension (`type` match).
+2. Test the extension against **at least one** template locally.
+3. If the change affects dependencies, also test the full matrix of that template (all extensions at once) to detect peer conflicts.
+
+---
+
+## 7. Handling incompatible extensions
+
+When two extensions cannot be used together, declare it explicitly.
+
+### 7.1 Via `incompatibleWith`
+
+In `templates.json`, add `incompatibleWith` to both extensions:
+
+```json
+{
+  "slug": "react-redux-saga",
+  "incompatibleWith": ["react-redux-thunk"]
+}
+```
+
+The CI generator reads this and never selects both in the same combination. The full matrix generator also respects it.
+
+### 7.2 Via `.npmrc`
+
+If the incompatibility is only a peer-dependency resolution issue at install time, a `.npmrc` with `legacy-peer-deps=true` may be enough. Several extensions already do this:
+
+```text
+extensions/react-hookstate/.npmrc
+extensions/react-semantic-ui/.npmrc
+extensions/storybook/.npmrc
+```
+
+This is cheaper than `incompatibleWith` because it keeps both extensions available. Use it when the conflict is a semver-peer restriction, not a logical conflict.
+
+### 7.3 Decision matrix
+
+| Situation | Use |
+|---|---|
+| Extensions logically conflict (e.g., two Redux middleware choices) | `incompatibleWith` |
+| Peer dependency disagreement that resolves with `legacy-peer-deps` | `.npmrc` |
+| Extension breaks a specific template but works elsewhere | Isolate the problem; consider template-specific branch or do not list the type match |
+| Extension is obsolete | Remove from `templates.json` or archive |
+
+---
+
+## 8. Updating dependencies inside a template or extension
+
+1. Open the relevant `package.json` (or `package/index.js` for templates).
+2. Use `npm view` to find the latest compatible version.
+3. Update the range conservatively (prefer caret minors, not arbitrary majors).
+4. Re-scaffold locally and run validation.
+5. If the update is security-related, also read [MAINTENANCE_SECURITY.md](./MAINTENANCE_SECURITY.md).
+
+See [MAINTENANCE_DEPENDENCIES.md](./MAINTENANCE_DEPENDENCIES.md) for deeper dependency troubleshooting.
+
+---
+
+## 9. Local validation command
+
+Use this exact sequence after every template or extension change:
+
+```bash
+REPO=/absolute/path/to/cna-templates
+CI=true npx create-awesome-node-app@latest my-app \
+  -t "file://$REPO?subdir=templates/<slug>" \
+  --addons "file://$REPO?subdir=extensions/<ext1>" \
+         "file://$REPO?subdir=extensions/<ext2>"
+
+cd my-app
+npm install
+npm run format --if-present
+npm run lint:fix --if-present
+npm run lint --if-present
+npm run type-check --if-present
+SKIP_ENV_VALIDATION=true npm run build --if-present
+```
+
+If any step fails, fix the template or extension, then regenerate from scratch. Do not reuse `my-app` between attempts because files are merged, not reset.
+
+---
+
+## 10. Checklist
+
+- [ ] Registry entry is valid against `templates.schema.json`.
+- [ ] `type` matches between template and compatible extensions.
+- [ ] `category` is set to avoid random CI selecting duplicates.
+- [ ] `incompatibleWith` is defined for mutually exclusive extensions.
+- [ ] `.npmrc` is added if peer-dependency conflicts exist.
+- [ ] `.template` files use available EJS variables.
+- [ ] Local validation passes.
+- [ ] Full matrix worst case (all compatible extensions) is tested for risky changes.


### PR DESCRIPTION
## Summary

This PR introduces a complete maintenance runbook for the Create-Node-App ecosystem so future AI sessions and human contributors can operate the repos consistently.

## Docs added

- `docs/MAINTENANCE_RUNBOOK.md` — top-level index, constraints, decision tree, generic workflow, and common commands.
- `docs/MAINTENANCE_TEMPLATES.md` — how to inspect, fix, add, and update templates and extensions.
- `docs/MAINTENANCE_DEPENDENCIES.md` — dependency investigation, conflict resolution, and Dependabot workflows.
- `docs/MAINTENANCE_SECURITY.md` — security triage, Dependabot, CodeQL, and audit workflows.
- `docs/MAINTENANCE_CI.md` — workflow overview, log reading, manual runs, and YAML/JS script validation.
- `docs/MAINTENANCE_RELEASE.md` — changesets, npm Trusted Publishing, and release verification.

## README update

- Adds the runbook to the documentation table.
- Adds a copy-paste prompt at the end for AI assistants to use in future sessions.

## Why split into 6 files

The component split makes it easy for AI tools to retrieve only the relevant procedure and keeps each doc focused and searchable.

## Validation

- [x] All internal links point to existing files.
- [x] README renders correctly.
- [x] Knowledge mirror updated at `knowledge/processes/create-node-app-maintenance.md` in the workspace.