### PR TITLE
feat(remix-starter): redesign default landing page with new CNA identity

### DIFF
--- a/docs/DEFAULT_LANDING_DESIGN.md
+++ b/docs/DEFAULT_LANDING_DESIGN.md
@@ -1,0 +1,301 @@
+# Default Landing Design System
+
+> Visual identity and implementation guide for the default landing pages of Create-Node-App templates.
+>
+> This is a brand-new identity, independent of the public website.
+
+---
+
+## 1. Design principles
+
+1. **Cozy, not corporate.** Soft surfaces, warm neutrals, and friendly shapes.
+2. **Developer-first clarity.** Every landing explains what the user just scaffolded and where to start.
+3. **Motion with purpose.** Animations welcome the user; they never obstruct content.
+4. **No dependencies.** Landings must look good without Tailwind, shadcn, or any UI extension.
+5. **Dark default, light capable.** Projects ship dark by default and respect system preference via `prefers-color-scheme`.
+
+---
+
+## 2. Color palette
+
+### Brand colors
+
+| Token | Hex | Usage |
+|---|---|---|
+| `brand-amber` | `#f59e0b` | Primary accent, highlights, CTAs |
+| `brand-amber-dark` | `#d97706` | Hover states, secondary accents |
+| `brand-teal` | `#0d9488` | Success, links, secondary accent |
+| `brand-teal-soft` | `#14b8a6` | Soft teal surfaces |
+
+### Neutral colors
+
+| Token | Light mode | Dark mode (default) | Usage |
+|---|---|---|---|
+| `bg` | `#fffcf5` | `#0f172a` | Page background |
+| `surface` | `#ffffff` | `#1e293b` | Cards, panels |
+| `surface-elevated` | `#fffbeb` | `#27364f` | Hover/elevated cards |
+| `text` | `#1f2937` | `#f8fafc` | Primary text |
+| `text-muted` | `#6b7280` | `#94a3b8` | Secondary text |
+| `border` | `#fed7aa` | `#334155` | Subtle borders |
+| `glow` | `rgba(245, 158, 11, 0.15)` | `rgba(245, 158, 11, 0.12)` | Ambient glows |
+
+### Semantic colors
+
+| Token | Hex | Usage |
+|---|---|---|
+| `success` | `#14b8a6` | Feature available, success messages |
+| `warning` | `#f59e0b` | Warnings |
+| `error` | `#ef4444` | Errors |
+
+### Gradient
+
+Primary brand gradient:
+
+```css
+background: linear-gradient(135deg, #f59e0b 0%, #d97706 55%, #0d9488 100%);
+```
+
+Use it for:
+- Logo mark strokes.
+- Primary buttons.
+- Hero headline accent.
+
+---
+
+## 3. Typography
+
+### Font stack
+
+```css
+font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+```
+
+For monospaced snippets:
+
+```css
+font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+```
+
+### Type scale
+
+| Name | Size | Weight | Line-height | Usage |
+|---|---|---|---|---|
+| Hero | `clamp(2rem, 5vw, 3.5rem)` | 800 | 1.1 | Main headline |
+| H2 | `clamp(1.5rem, 3vw, 2rem)` | 700 | 1.2 | Section titles |
+| H3 | `1.125rem` | 700 | 1.3 | Card titles |
+| Body | `1rem` | 400 | 1.65 | Paragraphs |
+| Small | `0.875rem` | 500 | 1.5 | Labels, badges |
+| Code | `0.8125rem` | 700 | 1.4 | Inline paths/commands |
+
+---
+
+## 4. Spacing and shape
+
+### Radius
+
+| Token | Value | Usage |
+|---|---|---|
+| `radius-sm` | `0.5rem` (8px) | Buttons, badges |
+| `radius-md` | `0.75rem` (12px) | Small cards |
+| `radius-lg` | `1.25rem` (20px) | Large cards, panels |
+| `radius-xl` | `1.75rem` (28px) | Hero containers |
+| `radius-full` | `9999px` | Pills |
+
+### Shadows
+
+```css
+--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+--shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+--shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+--shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.25);
+```
+
+Use `shadow-glow` sparingly on hero containers.
+
+---
+
+## 5. Motion
+
+### Entrance animation
+
+```css
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+Apply with staggered delays:
+
+```css
+animation: fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+animation-delay: calc(var(--index) * 80ms);
+```
+
+### Hover transitions
+
+```css
+transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+```
+
+Card hover:
+
+```css
+.feature-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-lg), var(--shadow-glow);
+}
+```
+
+### Reduced motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+---
+
+## 6. Logo and assets
+
+Master assets live in `shared/assets/`:
+
+| File | Description |
+|---|---|
+| `shared/assets/logo-mark.svg` | Icon-only logo (64x64 viewBox) |
+| `shared/assets/logo-wordmark.svg` | Logo + "Create Awesome Node App" text |
+| `shared/assets/favicon.svg` | 32x32 favicon source |
+
+When updating the identity, edit the master files first, then copy the new versions into each template that needs them:
+
+- `templates/<name>/public/logo.svg` (or equivalent)
+- `templates/<name>/public/favicon.svg` / `favicon.ico`
+
+### Logo usage rules
+
+- Prefer the mark at 40–64px in navbars and footers.
+- Use the wordmark in the hero at 160–280px wide.
+- Never distort the SVG aspect ratio.
+- When placed on dark surfaces, the mark remains visible because the amber/teal gradient has enough contrast.
+
+---
+
+## 7. Landing page structure
+
+Every template landing should follow this layout:
+
+```
++----------------------------------+
+|  [Mark]  Create Awesome Node App |
++----------------------------------+
+|                                  |
+|  Welcome to <projectName>        |
+|  One command. Any stack.         |
+|                                  |
+|  [Primary CTA]  [Secondary]      |
+|                                  |
++----------------------------------+
+|  Feature cards (3-6 items)       |
++----------------------------------+
+|  Docs + next steps               |
++----------------------------------+
+|  Footer with links               |
++----------------------------------+
+```
+
+### Feature card content pattern
+
+Each feature card contains:
+
+1. A small amber or teal icon.
+2. A short title.
+3. One-sentence description.
+4. Optional doc link.
+
+Example cards per template:
+
+- **React Vite**: React 19, Vite 8, React Router 7, TypeScript, ESLint + Prettier, feature-based structure.
+- **Next.js**: Next.js 16 App Router, TypeScript, feature-based structure, login example, ESLint + Prettier.
+- **Remix**: React Router v7, TypeScript, ESLint + Prettier, fast builds.
+- **Astro**: Astro 7, static output, partial hydration, TypeScript.
+
+### Documentation links
+
+Link to the generated docs folder using relative paths:
+
+- `docs/README.md`
+- `docs/PROJECT_STRUCTURE.md`
+- `docs/COMPONENTS_AND_STYLING.md`
+- `docs/STATE_MANAGEMENT.md`
+
+Use a `DocsLink` helper component with an icon + label.
+
+---
+
+## 8. Implementation notes per stack
+
+### React Vite
+
+- Use plain CSS or CSS Modules for the landing.
+- Import `logo.svg` as a React component or `<img>`.
+- Avoid adding new runtime dependencies.
+
+### Next.js App Router
+
+- Use CSS Modules for the page.
+- Place shared color tokens in `globals.css`.
+- Keep metadata in `layout.tsx` if needed.
+
+### Remix / React Router
+
+- Use plain CSS files in `app/styles/`.
+- `LinksFunction` can preload the stylesheet.
+
+### Astro
+
+- Use scoped `<style>` inside `index.astro`.
+- Use CSS variables on `:root` for theming.
+
+### WebExtension
+
+- Inline SVG logo to avoid asset-path issues in popup.
+- Popup: compact vertical card, no heavy animations.
+- Newtab: full landing layout, can use more motion.
+
+### Turborepo
+
+- Update Storybook intro page CSS only.
+- Keep styled-components dependency in `packages/ui` if already present.
+
+---
+
+## 9. Accessibility
+
+- Text must meet WCAG 4.5:1 contrast.
+- Interactive elements must have visible focus states.
+- Respect `prefers-reduced-motion`.
+- Logo SVGs must include `<title>` and `role="img"`.
+- Avoid auto-playing motion that cannot be paused.
+
+---
+
+## 10. Updating this system
+
+1. Propose token changes in a dedicated issue.
+2. Update `shared/assets/*` and this document.
+3. Copy assets to each affected template.
+4. Update each landing implementation.
+5. Run the full matrix before merging.

--- a/shared/assets/favicon.svg
+++ b/shared/assets/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-labelledby="faviconTitle">
+  <title id="faviconTitle">Create Awesome Node App</title>
+  <defs>
+    <linearGradient id="cnaFav" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="#fff8f1"/>
+  <path
+    d="M16 5c-1.2 0-2.3.6-3 1.5l-7 11.2c-1.1 1.8-.2 4.2 2 4.7V24c0 2 1.6 3.6 3.6 3.6h8.8c2 0 3.6-1.6 3.6-3.6v-1.6c2.2-.5 3.1-2.9 2-4.7L19 6.5C18.3 5.6 17.2 5 16 5Z"
+    stroke="url(#cnaFav)"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="16" cy="14" r="2.5" fill="#f59e0b"/>
+  <circle cx="9.5" cy="24" r="2.5" fill="#0d9488"/>
+  <circle cx="22.5" cy="24" r="2.5" fill="#d97706"/>
+</svg>

--- a/shared/assets/logo-mark-dark.svg
+++ b/shared/assets/logo-mark-dark.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark on a dark background.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="55%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#14b8a6"/>
+    </linearGradient>
+    <linearGradient id="cnaDotTop" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#f59e0b"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#0f172a"/>
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="url(#cnaDotTop)"/>
+  <circle cx="20" cy="43" r="5" fill="#14b8a6"/>
+  <circle cx="44" cy="43" r="5" fill="#f59e0b"/>
+</svg>

--- a/shared/assets/logo-mark.svg
+++ b/shared/assets/logo-mark.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>

--- a/shared/assets/logo-wordmark.svg
+++ b/shared/assets/logo-wordmark.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 64" fill="none" aria-labelledby="wordmarkTitle wordmarkDesc" role="img">
+  <title id="wordmarkTitle">Create Awesome Node App</title>
+  <desc id="wordmarkDesc">CNA wordmark combining a cozy node nest mark with the project name.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+    <linearGradient id="cnaAccent" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Mark -->
+  <g transform="translate(0 0)">
+    <path
+      d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+      stroke="url(#cnaNest)"
+      stroke-width="5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      fill="none"
+    />
+    <circle cx="32" cy="27" r="5" fill="url(#cnaAccent)"/>
+    <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+    <circle cx="44" cy="43" r="5" fill="#d97706"/>
+  </g>
+
+  <!-- Text -->
+  <g transform="translate(80 14)">
+    <text x="0" y="30" fill="#1f2937" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="800" letter-spacing="-0.5">
+      Create Awesome
+    </text>
+    <text x="0" y="30" fill="url(#cnaNest)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="28" font-weight="800" letter-spacing="-0.5">
+      <tspan dx="190">Node App</tspan>
+    </text>
+  </g>
+</svg>

--- a/templates/nextjs-saas-ai-starter/public/logo.svg
+++ b/templates/nextjs-saas-ai-starter/public/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>

--- a/templates/nextjs-saas-ai-starter/src/app/favicon.svg
+++ b/templates/nextjs-saas-ai-starter/src/app/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-labelledby="faviconTitle">
+  <title id="faviconTitle">Create Awesome Node App</title>
+  <defs>
+    <linearGradient id="cnaFav" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="#fff8f1"/>
+  <path
+    d="M16 5c-1.2 0-2.3.6-3 1.5l-7 11.2c-1.1 1.8-.2 4.2 2 4.7V24c0 2 1.6 3.6 3.6 3.6h8.8c2 0 3.6-1.6 3.6-3.6v-1.6c2.2-.5 3.1-2.9 2-4.7L19 6.5C18.3 5.6 17.2 5 16 5Z"
+    stroke="url(#cnaFav)"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="16" cy="14" r="2.5" fill="#f59e0b"/>
+  <circle cx="9.5" cy="24" r="2.5" fill="#0d9488"/>
+  <circle cx="22.5" cy="24" r="2.5" fill="#d97706"/>
+</svg>

--- a/templates/nextjs-saas-ai-starter/src/shared/components/brand/Logo.tsx
+++ b/templates/nextjs-saas-ai-starter/src/shared/components/brand/Logo.tsx
@@ -51,11 +51,18 @@ export function AppLogo({ size = 'md', showText = true, href = '/', className, a
       ) : (
         <div
           className={cn(
-            'flex items-center justify-center rounded-xl brand-gradient shadow-sm transition-transform duration-300 group-hover:rotate-3',
+            'flex items-center justify-center rounded-xl overflow-hidden transition-transform duration-300 group-hover:rotate-3',
             s.icon,
           )}
         >
-          <span className={cn('font-bold text-white', s.iconText)}>A</span>
+          <Image
+            src="/logo.svg"
+            alt={displayName}
+            width={s.imgSize}
+            height={s.imgSize}
+            className="object-contain"
+            unoptimized
+          />
         </div>
       )}
       {showText && <span className={cn('font-bold brand-gradient-text', s.textMain)}>{displayName}</span>}

--- a/templates/nextjs-starter/[src]/app/favicon.svg
+++ b/templates/nextjs-starter/[src]/app/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-labelledby="faviconTitle">
+  <title id="faviconTitle">Create Awesome Node App</title>
+  <defs>
+    <linearGradient id="cnaFav" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="#fff8f1"/>
+  <path
+    d="M16 5c-1.2 0-2.3.6-3 1.5l-7 11.2c-1.1 1.8-.2 4.2 2 4.7V24c0 2 1.6 3.6 3.6 3.6h8.8c2 0 3.6-1.6 3.6-3.6v-1.6c2.2-.5 3.1-2.9 2-4.7L19 6.5C18.3 5.6 17.2 5 16 5Z"
+    stroke="url(#cnaFav)"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="16" cy="14" r="2.5" fill="#f59e0b"/>
+  <circle cx="9.5" cy="24" r="2.5" fill="#0d9488"/>
+  <circle cx="22.5" cy="24" r="2.5" fill="#d97706"/>
+</svg>

--- a/templates/nextjs-starter/[src]/app/globals.css
+++ b/templates/nextjs-starter/[src]/app/globals.css
@@ -1,21 +1,33 @@
 :root {
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-    'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-    'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
-  --foreground-rgb: 15, 23, 42;
-  --muted-rgb: 71, 85, 105;
-  --background-rgb: 248, 250, 252;
-  --surface-rgb: 255, 255, 255;
-  --border-rgb: 203, 213, 225;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --cna-bg: #0f172a;
+  --cna-surface: #1e293b;
+  --cna-surface-elevated: #27364f;
+  --cna-text: #f8fafc;
+  --cna-text-muted: #94a3b8;
+  --cna-border: #334155;
+  --cna-amber: #f59e0b;
+  --cna-amber-soft: #fbbf24;
+  --cna-amber-dark: #d97706;
+  --cna-teal: #0d9488;
+  --cna-teal-soft: #14b8a6;
+  --cna-glow: rgba(245, 158, 11, 0.12);
+  --cna-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --cna-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --cna-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.25);
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --foreground-rgb: 241, 245, 249;
-    --muted-rgb: 148, 163, 184;
-    --background-rgb: 2, 6, 23;
-    --surface-rgb: 15, 23, 42;
-    --border-rgb: 51, 65, 85;
+    --cna-bg: #fffcf5;
+    --cna-surface: #ffffff;
+    --cna-surface-elevated: #fffbeb;
+    --cna-text: #1f2937;
+    --cna-text-muted: #6b7280;
+    --cna-border: #fed7aa;
+    --cna-glow: rgba(245, 158, 11, 0.08);
+    --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.18);
   }
 }
 
@@ -29,15 +41,15 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
+  color: var(--cna-text);
   background:
-    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 32%),
-    linear-gradient(180deg, rgba(var(--surface-rgb), 0.5), rgb(var(--background-rgb)));
+    radial-gradient(circle at 20% 10%, var(--cna-glow), transparent 40%),
+    radial-gradient(circle at 80% 90%, var(--cna-glow), transparent 40%),
+    var(--cna-bg);
 }
 
 a {
@@ -53,4 +65,14 @@ a {
 
 .app {
   min-height: 100vh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/templates/nextjs-starter/[src]/app/layout.tsx
+++ b/templates/nextjs-starter/[src]/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Next.js Starter',
+  title: 'Next.js Starter - Create Awesome Node App',
   description: 'A polished feature-based Next.js starter generated with Create Awesome Node App',
 };
 

--- a/templates/nextjs-starter/[src]/app/page.module.css
+++ b/templates/nextjs-starter/[src]/app/page.module.css
@@ -1,193 +1,264 @@
-.main {
-  width: min(1120px, 100%);
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 4rem 1.5rem 3rem;
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.landing {
   min-height: 100vh;
-}
-
-.hero {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
 }
 
-.badge {
-  width: fit-content;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(var(--border-rgb), 0.8);
-  background: rgba(var(--surface-rgb), 0.72);
-  color: rgb(var(--muted-rgb));
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.brand {
+.header {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.brandMark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.9rem 1.1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(var(--border-rgb), 0.8);
-  background: rgba(var(--surface-rgb), 0.86);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
-}
-
-.hint {
-  color: rgb(var(--muted-rgb));
-  font-size: 0.95rem;
-}
-
-.title {
-  max-width: 14ch;
-  font-size: clamp(2.4rem, 7vw, 4.6rem);
-  line-height: 0.98;
-  letter-spacing: -0.05em;
-}
-
-.lead {
-  max-width: 62ch;
-  color: rgb(var(--muted-rgb));
-  font-size: 1.05rem;
-  line-height: 1.7;
-}
-
-.description {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem;
-  font-size: 0.92rem;
-}
-
-.description p {
-  margin: 0;
-  padding: 0.85rem 1rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(var(--border-rgb), 0.8);
-  background: rgba(var(--surface-rgb), 0.78);
-  color: rgb(var(--muted-rgb));
-}
-
-.code {
-  font-weight: 700;
-  font-family: var(--font-mono);
-  color: rgb(var(--foreground-rgb));
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.card {
-  padding: 1.2rem;
-  border-radius: 1.1rem;
-  border: 1px solid rgba(var(--border-rgb), 0.82);
-  background: rgba(var(--surface-rgb), 0.86);
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
-}
-
-.card h2 {
-  font-weight: 600;
-  margin-bottom: 0.6rem;
-  font-size: 1.05rem;
-}
-
-.card p {
-  margin: 0;
-  color: rgb(var(--muted-rgb));
-  line-height: 1.6;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--cna-border);
+  animation: fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .logo {
   display: block;
+  width: 40px;
+  height: 40px;
 }
 
-.checklist {
+.brand {
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+  color: var(--cna-text);
+}
+
+.main {
+  flex: 1;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.hero,
+.features .grid,
+.docs,
+.footer {
+  animation: fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--index, 0) * 80ms);
+}
+
+.hero {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  border-radius: 1.75rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--cna-amber-soft);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+  color: var(--cna-text);
+}
+
+.lead {
+  max-width: 52ch;
+  margin: 0 auto 1.75rem;
+  color: var(--cna-text-muted);
+  font-size: 1.125rem;
+  line-height: 1.65;
+}
+
+.actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1.4rem;
-  border-radius: 1.2rem;
-  border: 1px solid rgba(var(--border-rgb), 0.82);
-  background: rgba(var(--surface-rgb), 0.92);
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+  justify-content: center;
+  gap: 0.75rem;
 }
 
-.checklist h2 {
-  margin-bottom: 0.75rem;
-  font-size: 1.1rem;
-}
-
-.list {
-  padding-left: 1.2rem;
-  color: rgb(var(--muted-rgb));
-  line-height: 1.7;
-}
-
-.resource {
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px;
-  padding: 0.85rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(var(--border-rgb), 0.9);
-  background: rgb(var(--foreground-rgb));
-  color: rgb(var(--background-rgb));
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  font-weight: 700;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.buttonPrimary {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 55%, #0d9488 100%);
+  color: #fff;
+  box-shadow: var(--cna-shadow-md);
+}
+
+.buttonPrimary:hover {
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.buttonSecondary {
+  background: var(--cna-surface-elevated);
+  color: var(--cna-text);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+}
+
+.buttonSecondary:hover {
+  background: var(--cna-border);
+}
+
+.sectionTitle {
+  margin: 3rem 0 1.25rem;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--cna-text);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cardIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.625rem;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--cna-amber-soft);
+  font-size: 1.125rem;
+}
+
+.cardTitle {
+  margin: 0 0 0.35rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--cna-text);
+}
+
+.cardText {
+  margin: 0;
+  color: var(--cna-text-muted);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+}
+
+.docList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.docLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  color: var(--cna-text);
+  text-decoration: none;
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.docLink:hover {
+  transform: translateX(4px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-md);
+}
+
+.docLabel {
   font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.docArrow {
+  color: var(--cna-amber);
+  font-weight: 700;
 }
 
 .footer {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  color: rgb(var(--muted-rgb));
-  font-size: 0.9rem;
+  padding: 2rem 1.5rem;
+  border-top: 1px solid var(--cna-border);
+  text-align: center;
+  color: var(--cna-text-muted);
+  font-size: 0.875rem;
 }
 
-@media (max-width: 700px) {
-  .grid {
-    grid-template-columns: 1fr;
-  }
+.footer a {
+  color: var(--cna-amber-soft);
+  text-decoration: none;
+  font-weight: 600;
+}
 
+.footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
   .main {
-    padding-top: 3rem;
+    padding: 1.5rem 1rem;
   }
 
-  .brand {
-    align-items: flex-start;
+  .hero {
+    padding: 1.75rem 1rem;
   }
 
-  .title {
-    max-width: none;
-  }
-
-  .checklist {
+  .actions {
+    flex-direction: column;
     align-items: stretch;
   }
 
-  .description {
-    flex-direction: column;
-  }
-}
-
-@media (min-width: 701px) and (max-width: 1120px) {
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .button {
+    width: 100%;
   }
 }

--- a/templates/nextjs-starter/[src]/app/page.tsx.template
+++ b/templates/nextjs-starter/[src]/app/page.tsx.template
@@ -54,16 +54,16 @@ export default function Home() {
       <main className={styles.main}>
         <section className={styles.hero} style={{ "--index": 0 } as React.CSSProperties}>
           <span className={styles.eyebrow}>Your project is ready</span>
-          <h1 className={styles.title}>Next.js Starter</h1>
+          <h1 className={styles.title}><%= projectName %></h1>
           <p className={styles.lead}>
             A cozy Next.js starter with a feature-based foundation. Everything you need to start building your next
             page.
           </p>
           <div className={styles.actions}>
-            <a href="src/app/page.tsx" className={`${styles.button} ${styles.buttonPrimary}`}>
+            <a href="<%- srcDir %>/app/page.tsx" className={styles.button + " " + styles.buttonPrimary}>
               Start editing
             </a>
-            <a href="./docs/README.md" className={`${styles.button} ${styles.buttonSecondary}`}>
+            <a href="./docs/README.md" className={styles.button + " " + styles.buttonSecondary}>
               Read the docs
             </a>
           </div>

--- a/templates/nextjs-starter/public/logo.svg
+++ b/templates/nextjs-starter/public/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>

--- a/templates/react-vite-starter/[src]/pages/Landing.css
+++ b/templates/react-vite-starter/[src]/pages/Landing.css
@@ -1,80 +1,308 @@
-.landing {
+/* CNA default landing page — React Vite starter */
+
+:root {
+  --cna-bg: #0f172a;
+  --cna-surface: #1e293b;
+  --cna-surface-elevated: #27364f;
+  --cna-text: #f8fafc;
+  --cna-text-muted: #94a3b8;
+  --cna-border: #334155;
+  --cna-amber: #f59e0b;
+  --cna-amber-soft: #fbbf24;
+  --cna-amber-dark: #d97706;
+  --cna-teal: #14b8a6;
+  --cna-glow: rgba(245, 158, 11, 0.12);
+  --cna-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --cna-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --cna-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.25);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --cna-bg: #fffcf5;
+    --cna-surface: #ffffff;
+    --cna-surface-elevated: #fffbeb;
+    --cna-text: #1f2937;
+    --cna-text-muted: #6b7280;
+    --cna-border: #fed7aa;
+    --cna-glow: rgba(245, 158, 11, 0.08);
+    --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.18);
+  }
+}
+
+@keyframes cna-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.cna-landing {
   min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 2rem;
+  display: flex;
+  flex-direction: column;
   background:
-    radial-gradient(circle at top, rgba(99, 102, 241, 0.16), transparent 32%),
-    linear-gradient(180deg, #0f172a 0%, #111827 100%);
-  color: #e5eefc;
+    radial-gradient(circle at 20% 10%, var(--cna-glow), transparent 40%),
+    radial-gradient(circle at 80% 90%, var(--cna-glow), transparent 40%),
+    var(--cna-bg);
+  color: var(--cna-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.65;
 }
 
-.landing__surface {
-  width: min(720px, 100%);
-  padding: 2rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 1.5rem;
-  background: rgba(15, 23, 42, 0.78);
-  box-shadow: 0 24px 70px rgba(2, 6, 23, 0.45);
+.cna-landing__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--cna-border);
+  animation: cna-fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.landing__eyebrow {
+.cna-landing__logo {
+  display: block;
+  width: 40px;
+  height: 40px;
+}
+
+.cna-landing__brand {
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.cna-landing__main {
+  flex: 1;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.cna-landing__hero,
+.cna-landing__features,
+.cna-landing__docs,
+.cna-landing__footer {
+  animation: cna-fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--index, 0) * 80ms);
+}
+
+.cna-landing__hero {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  border-radius: 1.75rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__eyebrow {
   display: inline-flex;
   margin-bottom: 1rem;
-  padding: 0.35rem 0.75rem;
+  padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  background: rgba(59, 130, 246, 0.14);
-  color: #bfdbfe;
-  font-size: 0.85rem;
-  font-weight: 600;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--cna-amber-soft);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
-.landing__title {
+.cna-landing__title {
   margin: 0 0 0.75rem;
-  font-size: clamp(2.4rem, 8vw, 4.25rem);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
   line-height: 1.1;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.04em;
 }
 
-.landing__lead {
-  margin: 0 0 1.5rem;
-  max-width: 40rem;
-  color: #cbd5e1;
-  line-height: 1.7;
+.cna-landing__lead {
+  max-width: 52ch;
+  margin: 0 auto 1.75rem;
+  color: var(--cna-text-muted);
+  font-size: 1.125rem;
 }
 
-.landing__meta {
+.cna-landing__actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.75rem;
-  margin-bottom: 1.5rem;
 }
 
-.landing__meta p {
-  margin: 0;
-  padding: 0.8rem 0.95rem;
-  border-radius: 0.95rem;
-  background: rgba(30, 41, 59, 0.9);
-  color: #dbeafe;
+.cna-landing__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  font-weight: 700;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.landing__meta code {
+.cna-landing__button:hover {
+  transform: translateY(-2px);
+}
+
+.cna-landing__button--primary {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 55%, #0d9488 100%);
+  color: #fff;
+  box-shadow: var(--cna-shadow-md);
+}
+
+.cna-landing__button--primary:hover {
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__button--secondary {
+  background: var(--cna-surface-elevated);
+  color: var(--cna-text);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+}
+
+.cna-landing__button--secondary:hover {
+  background: var(--cna-border);
+}
+
+.cna-landing__section-title {
+  margin: 3rem 0 1.25rem;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.cna-landing__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.cna-landing__card {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.cna-landing__card:hover {
+  transform: translateY(-3px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.625rem;
+  background: rgba(245, 158, 11, 0.12);
+  font-size: 1.125rem;
+}
+
+.cna-landing__card-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.0625rem;
   font-weight: 700;
 }
 
-.landing__list {
+.cna-landing__card-text {
   margin: 0;
-  padding-left: 1.2rem;
-  color: #cbd5e1;
-  line-height: 1.8;
+  color: var(--cna-text-muted);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+}
+
+.cna-landing__doc-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cna-landing__doc-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  color: var(--cna-text);
+  text-decoration: none;
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.cna-landing__doc-link:hover {
+  transform: translateX(4px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-md);
+}
+
+.cna-landing__doc-label {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.cna-landing__doc-arrow {
+  color: var(--cna-amber);
+  font-weight: 700;
+}
+
+.cna-landing__footer {
+  padding: 2rem 1.5rem;
+  border-top: 1px solid var(--cna-border);
+  text-align: center;
+  color: var(--cna-text-muted);
+  font-size: 0.875rem;
+}
+
+.cna-landing__footer a {
+  color: var(--cna-amber-soft);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cna-landing__footer a:hover {
+  text-decoration: underline;
 }
 
 @media (max-width: 640px) {
-  .landing {
-    padding: 1rem;
+  .cna-landing__main {
+    padding: 1.5rem 1rem;
   }
 
-  .landing__surface {
-    padding: 1.5rem;
+  .cna-landing__hero {
+    padding: 1.75rem 1rem;
+  }
+
+  .cna-landing__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cna-landing__button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cna-landing *,
+  .cna-landing *::before,
+  .cna-landing *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/templates/react-vite-starter/[src]/pages/Landing.tsx.template
+++ b/templates/react-vite-starter/[src]/pages/Landing.tsx.template
@@ -1,35 +1,121 @@
 import React from 'react';
 import './Landing.css';
+import logo from '/logo.svg';
 
-const starterHighlights = [
-  'Feature-based structure ready for scale.',
-  'Routing is already wired so you can start adding screens.',
-  'Compatible addons can layer UI, state, tooling, and more.',
+interface Feature {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+const features: Feature[] = [
+  {
+    icon: '⚡',
+    title: 'Vite 8',
+    description: 'Instant HMR and a fast, opinionated build pipeline.',
+  },
+  {
+    icon: '⚛️',
+    title: 'React 19',
+    description: 'Latest React with modern patterns and future-ready APIs.',
+  },
+  {
+    icon: '🧭',
+    title: 'React Router 7',
+    description: 'Client-side routing already wired for nested routes.',
+  },
+  {
+    icon: '🛡️',
+    title: 'TypeScript + ESLint + Prettier',
+    description: 'Static typing and consistent, automated code style.',
+  },
+  {
+    icon: '📦',
+    title: 'Feature-based structure',
+    description: 'Scale by co-locating routes, state, and components.',
+  },
+  {
+    icon: '🧩',
+    title: 'Addon ready',
+    description: 'Layer UI libraries, state tools, testing, and deployment.',
+  },
+];
+
+const docs = [
+  { label: 'Project overview', href: './docs/README.md' },
+  { label: 'Project structure', href: './docs/PROJECT_STRUCTURE.md' },
+  { label: 'Components & styling', href: './docs/COMPONENTS_AND_STYLING.md' },
+  { label: 'State management', href: './docs/STATE_MANAGEMENT.md' },
 ];
 
 const Landing = () => (
-  <section className="landing">
-    <div className="landing__surface">
-      <span className="landing__eyebrow">Create Awesome Node App</span>
-      <h1 className="landing__title"><%= projectName %></h1>
-      <p className="landing__lead">A lightweight React + Vite starter with a clean foundation for your next feature.</p>
+  <div className="cna-landing">
+    <header className="cna-landing__header">
+      <img src={logo} alt="Create Awesome Node App" className="cna-landing__logo" width="40" height="40" />
+      <span className="cna-landing__brand">Create Awesome Node App</span>
+    </header>
 
-      <div className="landing__meta">
-        <p>
-          Start editing <code><%= srcDir %>/pages/Landing.tsx</code>
+    <main className="cna-landing__main">
+      <section className="cna-landing__hero" style={{ '--index': 0 } as React.CSSProperties}>
+        <span className="cna-landing__eyebrow">Your project is ready</span>
+        <h1 className="cna-landing__title"><%= projectName %></h1>
+        <p className="cna-landing__lead">
+          A cozy React + Vite starter with a feature-based foundation. Everything you need to start building your next
+          screen.
         </p>
-        <p>
-          Add features in <code><%= srcDir %>/features</code>
-        </p>
-      </div>
+        <div className="cna-landing__actions">
+          <a href={`<%= srcDir %>/pages/Landing.tsx`} className="cna-landing__button cna-landing__button--primary">
+            Start editing
+          </a>
+          <a href="./docs/README.md" className="cna-landing__button cna-landing__button--secondary">
+            Read the docs
+          </a>
+        </div>
+      </section>
 
-      <ul className="landing__list">
-        {starterHighlights.map((item) => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-    </div>
-  </section>
+      <section className="cna-landing__features">
+        <h2 className="cna-landing__section-title">What is inside</h2>
+        <div className="cna-landing__grid">
+          {features.map((feature, index) => (
+            <article
+              key={feature.title}
+              className="cna-landing__card"
+              style={{ '--index': index + 1 } as React.CSSProperties}
+            >
+              <span className="cna-landing__card-icon" aria-hidden="true">
+                {feature.icon}
+              </span>
+              <h3 className="cna-landing__card-title">{feature.title}</h3>
+              <p className="cna-landing__card-text">{feature.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="cna-landing__docs" style={{ '--index': features.length + 1 } as React.CSSProperties}>
+        <h2 className="cna-landing__section-title">Next steps</h2>
+        <nav className="cna-landing__doc-list" aria-label="Documentation">
+          {docs.map((doc) => (
+            <a key={doc.label} href={doc.href} className="cna-landing__doc-link">
+              <span className="cna-landing__doc-label">{doc.label}</span>
+              <span className="cna-landing__doc-arrow" aria-hidden="true">
+                →
+              </span>
+            </a>
+          ))}
+        </nav>
+      </section>
+    </main>
+
+    <footer className="cna-landing__footer" style={{ '--index': features.length + 2 } as React.CSSProperties}>
+      <p>
+        Generated with{' '}
+        <a href="https://www.npmjs.com/package/create-awesome-node-app" target="_blank" rel="noreferrer">
+          create-awesome-node-app
+        </a>
+      </p>
+    </footer>
+  </div>
 );
 
 export default Landing;

--- a/templates/react-vite-starter/public/favicon.svg
+++ b/templates/react-vite-starter/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-labelledby="faviconTitle">
+  <title id="faviconTitle">Create Awesome Node App</title>
+  <defs>
+    <linearGradient id="cnaFav" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="#fff8f1"/>
+  <path
+    d="M16 5c-1.2 0-2.3.6-3 1.5l-7 11.2c-1.1 1.8-.2 4.2 2 4.7V24c0 2 1.6 3.6 3.6 3.6h8.8c2 0 3.6-1.6 3.6-3.6v-1.6c2.2-.5 3.1-2.9 2-4.7L19 6.5C18.3 5.6 17.2 5 16 5Z"
+    stroke="url(#cnaFav)"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="16" cy="14" r="2.5" fill="#f59e0b"/>
+  <circle cx="9.5" cy="24" r="2.5" fill="#0d9488"/>
+  <circle cx="22.5" cy="24" r="2.5" fill="#d97706"/>
+</svg>

--- a/templates/react-vite-starter/public/logo.svg
+++ b/templates/react-vite-starter/public/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>

--- a/templates/remix-starter/app/root.tsx.template
+++ b/templates/remix-starter/app/root.tsx.template
@@ -1,11 +1,14 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 
+import "./styles/landing.css";
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/remix-starter/app/routes/_index.tsx.template
+++ b/templates/remix-starter/app/routes/_index.tsx.template
@@ -1,12 +1,93 @@
-export function meta() {
-  return [{ title: "<%= projectName %>" }];
-}
+import type { MetaFunction } from "react-router";
+
+const features = [
+  { icon: "🧭", title: "React Router v7", description: "Modern data APIs and fast client-side navigation." },
+  { icon: "⚛️", title: "React 19", description: "Latest React with modern patterns and future-ready APIs." },
+  { icon: "🛡️", title: "TypeScript", description: "Static typing across routes and components." },
+  { icon: "⚡", title: "Vite", description: "Fast builds and instant HMR for rapid development." },
+  { icon: "📦", title: "Feature-based structure", description: "Scale by co-locating routes, state, and components." },
+  { icon: "🧩", title: "Addon ready", description: "Layer UI libraries, state tools, testing, and deployment." },
+];
+
+const docs = [
+  { label: "Project overview", href: "./docs/README.md" },
+  { label: "Project structure", href: "./docs/PROJECT_STRUCTURE.md" },
+  { label: "Components & styling", href: "./docs/COMPONENTS_AND_STYLING.md" },
+  { label: "State management", href: "./docs/STATE_MANAGEMENT.md" },
+];
+
+export const meta: MetaFunction = () => {
+  return [{ title: "<%= projectName %> - Create Awesome Node App" }];
+};
 
 export default function Home() {
   return (
-    <main style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
-      <h1>Welcome to <%= projectName %></h1>
-      <p>Built with React Router v7</p>
-    </main>
+    <div className="cna-landing">
+      <header className="cna-landing__header">
+        <img src="/logo.svg" alt="Create Awesome Node App" className="cna-landing__logo" width="40" height="40" />
+        <span className="cna-landing__brand">Create Awesome Node App</span>
+      </header>
+
+      <main className="cna-landing__main">
+        <section className="cna-landing__hero" style={{ "--index": 0 } as React.CSSProperties}>
+          <span className="cna-landing__eyebrow">Your project is ready</span>
+          <h1 className="cna-landing__title"><%= projectName %></h1>
+          <p className="cna-landing__lead">
+            A cozy React Router starter with feature-based folders. Everything you need to start building your next
+            route.
+          </p>
+          <div className="cna-landing__actions">
+            <a href="/app/routes/_index.tsx" className="cna-landing__button cna-landing__button--primary">
+              Start editing
+            </a>
+            <a href="./docs/README.md" className="cna-landing__button cna-landing__button--secondary">
+              Read the docs
+            </a>
+          </div>
+        </section>
+
+        <section className="cna-landing__features">
+          <h2 className="cna-landing__section-title">What is inside</h2>
+          <div className="cna-landing__grid">
+            {features.map((feature, index) => (
+              <article
+                key={feature.title}
+                className="cna-landing__card"
+                style={{ "--index": index + 1 } as React.CSSProperties}
+              >
+                <span className="cna-landing__card-icon" aria-hidden="true">
+                  {feature.icon}
+                </span>
+                <h3 className="cna-landing__card-title">{feature.title}</h3>
+                <p className="cna-landing__card-text">{feature.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="cna-landing__docs" style={{ "--index": features.length + 1 } as React.CSSProperties}>
+          <h2 className="cna-landing__section-title">Next steps</h2>
+          <nav className="cna-landing__doc-list" aria-label="Documentation">
+            {docs.map((doc) => (
+              <a key={doc.label} href={doc.href} className="cna-landing__doc-link">
+                <span className="cna-landing__doc-label">{doc.label}</span>
+                <span className="cna-landing__doc-arrow" aria-hidden="true">
+                  →
+                </span>
+              </a>
+            ))}
+          </nav>
+        </section>
+      </main>
+
+      <footer className="cna-landing__footer" style={{ "--index": features.length + 2 } as React.CSSProperties}>
+        <p>
+          Generated with{" "}
+          <a href="https://www.npmjs.com/package/create-awesome-node-app" target="_blank" rel="noreferrer">
+            create-awesome-node-app
+          </a>
+        </p>
+      </footer>
+    </div>
   );
 }

--- a/templates/remix-starter/app/styles/landing.css
+++ b/templates/remix-starter/app/styles/landing.css
@@ -1,0 +1,308 @@
+/* CNA default landing page — Remix / React Router starter */
+
+:root {
+  --cna-bg: #0f172a;
+  --cna-surface: #1e293b;
+  --cna-surface-elevated: #27364f;
+  --cna-text: #f8fafc;
+  --cna-text-muted: #94a3b8;
+  --cna-border: #334155;
+  --cna-amber: #f59e0b;
+  --cna-amber-soft: #fbbf24;
+  --cna-amber-dark: #d97706;
+  --cna-teal: #14b8a6;
+  --cna-glow: rgba(245, 158, 11, 0.12);
+  --cna-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --cna-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --cna-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.25);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --cna-bg: #fffcf5;
+    --cna-surface: #ffffff;
+    --cna-surface-elevated: #fffbeb;
+    --cna-text: #1f2937;
+    --cna-text-muted: #6b7280;
+    --cna-border: #fed7aa;
+    --cna-glow: rgba(245, 158, 11, 0.08);
+    --cna-shadow-glow: 0 0 40px -10px rgba(245, 158, 11, 0.18);
+  }
+}
+
+@keyframes cna-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.cna-landing {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(circle at 20% 10%, var(--cna-glow), transparent 40%),
+    radial-gradient(circle at 80% 90%, var(--cna-glow), transparent 40%),
+    var(--cna-bg);
+  color: var(--cna-text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.65;
+}
+
+.cna-landing__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--cna-border);
+  animation: cna-fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.cna-landing__logo {
+  display: block;
+  width: 40px;
+  height: 40px;
+}
+
+.cna-landing__brand {
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.cna-landing__main {
+  flex: 1;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.cna-landing__hero,
+.cna-landing__features,
+.cna-landing__docs,
+.cna-landing__footer {
+  animation: cna-fade-in-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--index, 0) * 80ms);
+}
+
+.cna-landing__hero {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  border-radius: 1.75rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__eyebrow {
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--cna-amber-soft);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.cna-landing__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.cna-landing__lead {
+  max-width: 52ch;
+  margin: 0 auto 1.75rem;
+  color: var(--cna-text-muted);
+  font-size: 1.125rem;
+}
+
+.cna-landing__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.cna-landing__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  font-weight: 700;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.cna-landing__button:hover {
+  transform: translateY(-2px);
+}
+
+.cna-landing__button--primary {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 55%, #0d9488 100%);
+  color: #fff;
+  box-shadow: var(--cna-shadow-md);
+}
+
+.cna-landing__button--primary:hover {
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__button--secondary {
+  background: var(--cna-surface-elevated);
+  color: var(--cna-text);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+}
+
+.cna-landing__button--secondary:hover {
+  background: var(--cna-border);
+}
+
+.cna-landing__section-title {
+  margin: 3rem 0 1.25rem;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.cna-landing__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.cna-landing__card {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.cna-landing__card:hover {
+  transform: translateY(-3px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-lg), var(--cna-shadow-glow);
+}
+
+.cna-landing__card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.625rem;
+  background: rgba(245, 158, 11, 0.12);
+  font-size: 1.125rem;
+}
+
+.cna-landing__card-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+}
+
+.cna-landing__card-text {
+  margin: 0;
+  color: var(--cna-text-muted);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+}
+
+.cna-landing__doc-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cna-landing__doc-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: var(--cna-surface);
+  border: 1px solid var(--cna-border);
+  color: var(--cna-text);
+  text-decoration: none;
+  box-shadow: var(--cna-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.cna-landing__doc-link:hover {
+  transform: translateX(4px);
+  background: var(--cna-surface-elevated);
+  box-shadow: var(--cna-shadow-md);
+}
+
+.cna-landing__doc-label {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.cna-landing__doc-arrow {
+  color: var(--cna-amber);
+  font-weight: 700;
+}
+
+.cna-landing__footer {
+  padding: 2rem 1.5rem;
+  border-top: 1px solid var(--cna-border);
+  text-align: center;
+  color: var(--cna-text-muted);
+  font-size: 0.875rem;
+}
+
+.cna-landing__footer a {
+  color: var(--cna-amber-soft);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cna-landing__footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .cna-landing__main {
+    padding: 1.5rem 1rem;
+  }
+
+  .cna-landing__hero {
+    padding: 1.75rem 1rem;
+  }
+
+  .cna-landing__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cna-landing__button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cna-landing *,
+  .cna-landing *::before,
+  .cna-landing *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/templates/remix-starter/app/types/css.d.ts
+++ b/templates/remix-starter/app/types/css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const content: string;
+  export default content;
+}

--- a/templates/remix-starter/public/favicon.svg
+++ b/templates/remix-starter/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" aria-labelledby="faviconTitle">
+  <title id="faviconTitle">Create Awesome Node App</title>
+  <defs>
+    <linearGradient id="cnaFav" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="#fff8f1"/>
+  <path
+    d="M16 5c-1.2 0-2.3.6-3 1.5l-7 11.2c-1.1 1.8-.2 4.2 2 4.7V24c0 2 1.6 3.6 3.6 3.6h8.8c2 0 3.6-1.6 3.6-3.6v-1.6c2.2-.5 3.1-2.9 2-4.7L19 6.5C18.3 5.6 17.2 5 16 5Z"
+    stroke="url(#cnaFav)"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="16" cy="14" r="2.5" fill="#f59e0b"/>
+  <circle cx="9.5" cy="24" r="2.5" fill="#0d9488"/>
+  <circle cx="22.5" cy="24" r="2.5" fill="#d97706"/>
+</svg>

--- a/templates/remix-starter/public/logo.svg
+++ b/templates/remix-starter/public/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>

--- a/templates/remix-starter/tsconfig.json.template
+++ b/templates/remix-starter/tsconfig.json.template
@@ -16,5 +16,5 @@
       "~/*": ["./<%= srcDir %>/*"]
     }
   },
-  "include": [".react-router/types/**/*", "<%= srcDir %>"]
+  "include": [".react-router/types/**/*", "<%= srcDir %>", "<%= srcDir %>/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Redesigns the default landing page of `remix-starter` to match the new cozy, animated CNA identity defined in #165.

## What changed

- Added `app/styles/landing.css` with CNA design tokens, dark/light modes, entrance animations, and reduced-motion support.
- Added `app/types/css.d.ts` so TypeScript accepts side-effect CSS imports.
- Updated `tsconfig.json.template` to include declaration files.
- Rewrote `root.tsx.template` to import the stylesheet and add a favicon link.
- Rewrote `_index.tsx.template` with header, hero, feature cards, documentation links, and footer.
- Added `public/logo.svg` and `public/favicon.svg` from `shared/assets/`.

## Design notes

- Warm amber + teal gradient for CTAs.
- Dark by default, light via `prefers-color-scheme`.
- Respects `prefers-reduced-motion`.
- No new runtime dependencies.

## Validation

- [x] `CI=true npx create-awesome-node-app@latest ...` with local `remix-starter` template.
- [x] `npm run type-check` passes.
- [x] `npm run build` passes.

## Related issues

Closes #169.
Part of #164.