### PR TITLE
feat(extensions): align UI extension demo colors with CNA identity

### DIFF
--- a/extensions/react-shadcn/[src]/components/ui/button.tsx.template
+++ b/extensions/react-shadcn/[src]/components/ui/button.tsx.template
@@ -7,8 +7,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-indigo-600 text-white hover:bg-indigo-500 focus-visible:outline-indigo-600',
-        secondary: 'bg-zinc-100 text-zinc-900 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700 focus-visible:outline-zinc-500',
+        default: 'bg-amber-500 text-white hover:bg-amber-600 focus-visible:outline-amber-500',
+        secondary: 'bg-teal-100 text-teal-900 hover:bg-teal-200 dark:bg-teal-900 dark:text-teal-100 dark:hover:bg-teal-800 focus-visible:outline-teal-500',
         ghost: 'hover:bg-zinc-100 dark:hover:bg-zinc-800',
         outline: 'border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800'
       },

--- a/extensions/react-shadcn/[src]/theme/global.css.template
+++ b/extensions/react-shadcn/[src]/theme/global.css.template
@@ -5,12 +5,12 @@
 
 :root {
   --radius: 8px;
-  --color-bg: 255 255 255;
-  --color-fg: 24 24 27;
+  --color-bg: 255 252 245;
+  --color-fg: 31 41 55;
 }
 .dark {
-  --color-bg: 24 24 27;
-  --color-fg: 244 244 245;
+  --color-bg: 15 23 42;
+  --color-fg: 248 250 252;
 }
 
 body { @apply bg-bg text-fg antialiased; }

--- a/extensions/react-tailwindcss/[src]/theme/tailwind.css.template
+++ b/extensions/react-tailwindcss/[src]/theme/tailwind.css.template
@@ -13,5 +13,5 @@ body { @apply bg-white text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100 antiali
 
 /* Example utility composition */
 .btn-primary {
-  @apply inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-60 disabled:cursor-not-allowed transition-colors;
+  @apply inline-flex items-center rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white shadow hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors;
 }

--- a/extensions/storybook/src/stories/Button.tsx.template
+++ b/extensions/storybook/src/stories/Button.tsx.template
@@ -14,8 +14,8 @@ export function Button({ label, onClick, variant = 'primary' }: ButtonProps) {
       onClick={onClick}
       style={{
         padding: '0.5rem 1rem',
-        background: variant === 'primary' ? '#0070f3' : '#eaeaea',
-        color: variant === 'primary' ? '#fff' : '#000',
+        background: variant === 'primary' ? '#f59e0b' : '#f1f5f9',
+        color: variant === 'primary' ? '#fff' : '#0f172a',
         border: 'none',
         borderRadius: '4px',
         cursor: 'pointer',


### PR DESCRIPTION
## Summary

Aligns the demo Button colors in UI extensions and Storybook with the amber/teal CNA identity.

## What changed

- `extensions/react-shadcn`: amber-500 primary, teal secondary, warm light/dark background tokens.
- `extensions/react-tailwindcss`: amber `.btn-primary` utility composition.
- `extensions/storybook`: amber primary / slate secondary demo button colors.

## Design notes

- These are example/demo components only; consumer projects override as needed.
- Keeps existing Tailwind class usage and shadcn cva structure intact.

## Validation

- [x] No syntax errors in modified `.template` files.
- [ ] Full build not run for every affected template+extension combination; the `react-tailwindcss` / `react-shadcn` extensions currently fail `npm run build` due to an unrelated Tailwind v4 PostCSS plugin issue (tracked separately).

## Related issues

Closes #173.
Part of #164.