### PR TITLE
fix: remove deprecated esbuild config for Vite 8 (Rolldown/OXC)

### DIFF
--- a/extensions/react-electron-vite/vite.config.ts.template
+++ b/extensions/react-electron-vite/vite.config.ts.template
@@ -66,16 +66,5 @@ export default defineConfig({
       '<%= projectImportPath%>': root + '/',
     },
   },
-  esbuild: {
-    loader: 'tsx',
-    include: '<%= srcDir%>/**/*.{ts,tsx,js,jsx}',
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
-        '.ts': 'tsx',
-      },
-    },
-  },
+
 });

--- a/extensions/react-million/vite.config.ts.template
+++ b/extensions/react-million/vite.config.ts.template
@@ -54,16 +54,5 @@ export default defineConfig({
       '<%= projectImportPath%>': root + '/',
     },
   },
-  esbuild: {
-    loader: 'tsx',
-    include: '<%= srcDir%>/**/*.{ts,tsx,js,jsx}',
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
-        '.ts': 'tsx',
-      },
-    },
-  },
+
 });

--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -60,19 +60,7 @@ export default defineConfig({
       '<%= projectImportPath %>': root + '/',
     },
   },
-  esbuild: {
-    loader: 'tsx',
-    include: '<%= srcDir %>/**/*.{ts,tsx,js,jsx}',
-  },
   build: {
     cssMinify: false,
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
-        '.ts': 'tsx',
-      },
-    },
   },
 });


### PR DESCRIPTION
## Summary

Vite 8 replaced esbuild with Rolldown and OXC for dependency optimization and transforms. The following deprecated options were removed:

- **Top-level `esbuild` config** — Vite 8 handles TSX/JSX natively via Rolldown/OXC
- **`optimizeDeps.esbuildOptions`** — deprecated; no longer needed as Rolldown handles dependency pre-bundling

### Files changed

| File | Change |
|------|--------|
| `templates/react-vite-starter/vite.config.ts.template` | Removed `esbuild` and `optimizeDeps.esbuildOptions` blocks (preserved `build.cssMinify`) |
| `extensions/react-electron-vite/vite.config.ts.template` | Same fix |
| `extensions/react-million/vite.config.ts.template` | Same fix |

### Verification

Tested by scaffolding a project with v0.10.0 — the deprecation warnings are gone after this fix.