### PR TITLE
fix(ci): repair broken template URLs in test-combinations heredoc

### DIFF
--- a/.github/workflows/test-combinations.yml
+++ b/.github/workflows/test-combinations.yml
@@ -47,7 +47,7 @@ jobs:
           const extLocalUrl = (ext) => {
             const match = ext.url.match(/\/extensions\/([^/]+)(?:\/|$)/);
             const dir = match ? match[1] : null;
-            return dir ? \`file://${repoDir}?subdir=extensions/${dir}\` : null;
+            return dir ? 'file://' + repoDir + '?subdir=extensions/' + dir : null;
           };
 
           const hasIncompatibility = (selected, candidate) => {
@@ -81,7 +81,7 @@ jobs:
             // Derive local template URL from the url field in templates.json
             const tplMatch = template.url.match(/\/templates\/([^/]+)(?:\/|$)/);
             const tplDir = tplMatch ? tplMatch[1] : null;
-            const templateUrl = tplDir ? \`file://${repoDir}?subdir=templates/${tplDir}\` : template.slug;
+            const templateUrl = tplDir ? 'file://' + repoDir + '?subdir=templates/' + tplDir : template.slug;
 
             return { template: template.slug, templateUrl, extensions: selectedExtensions.map(extLocalUrl).filter(Boolean) };
           });
@@ -170,7 +170,7 @@ jobs:
           const extLocalUrl = (ext) => {
             const match = ext.url.match(/\/extensions\/([^/]+)(?:\/|$)/);
             const dir = match ? match[1] : null;
-            return dir ? \`file://${repoDir}?subdir=extensions/\${dir}\` : null;
+            return dir ? 'file://' + repoDir + '?subdir=extensions/' + dir : null;
           };
 
           const hasIncompatibility = (selected, candidate) => {
@@ -208,7 +208,7 @@ jobs:
               // Derive local template URL from the url field in templates.json
               const tplMatch = template.url.match(/\/templates\/([^/]+)(?:\/|$)/);
               const tplDir = tplMatch ? tplMatch[1] : null;
-              const templateUrl = tplDir ? \`file://${repoDir}?subdir=templates/${tplDir}\` : template.slug;
+              const templateUrl = tplDir ? 'file://' + repoDir + '?subdir=templates/' + tplDir : template.slug;
 
               combinations.push({
                 template: template.slug,


### PR DESCRIPTION
## Problem

Every job in `test-combinations.yml` has been scaffolding an **empty project** since the workflow was created. All CI results were false positives.

### Root cause

The `generate-combinations` and `generate-full-matrix` steps run a Node.js script via an **unquoted bash heredoc** (`<<EOF`). Inside an unquoted heredoc, bash expands `${VAR}` expressions as shell variables before Node.js receives the script. `repoDir` and `tplDir` are JavaScript variables — they don't exist as bash variables — so both expand to the empty string.

| Expression | Bash processes | Node.js receives |
|---|---|---|
| `${repoDir}` | Shell expansion → `""` (not set) | `` (empty) ❌ |
| `${tplDir}` | Shell expansion → `""` (not set) | `` (empty) ❌ |
| `\${dir}` | `\$` → literal `$` | `${dir}` ✅ |

Result: every template URL becomes `file://?subdir=templates/` and every extension URL becomes `file://?subdir=extensions/`. The scaffolder creates a project with only `package.json` + `package-lock.json`. All `npm run * --if-present` commands are no-ops.

**Evidence** — every job in [run 29028233850](https://github.com/Create-Node-App/cna-templates/actions/runs/29028233850):
```
Test nextjs-starter      Template URL: file://?subdir=templates/
Test nestjs-boilerplate  Template URL: file://?subdir=templates/
... (all 10 templates identical)

tree output: ├── package-lock.json / └── package.json
```

## Fix

Replace JS template literals containing `${repoDir}` / `${tplDir}` with string concatenation, eliminating all `${}` syntax from the heredoc:

```js
// Before (bash eats ${repoDir} → empty string):
return dir ? `file://${repoDir}?subdir=extensions/${dir}` : null;

// After (no ${} in heredoc → bash has nothing to expand):
return dir ? 'file://' + repoDir + '?subdir=extensions/' + dir : null;
```

Four lines changed across two steps (`generate-combinations` and `generate-full-matrix`).

> Line 42 (`localUrl` in the `templates` map) is dead code — `randomCombinations` reads `data.templates` directly, never the mapped array. Left unchanged to keep the diff minimal.

## Verification

After this merges, `test-combinations.yml` on main should show:
```
Template URL: file:///home/runner/work/cna-templates/cna-templates?subdir=templates/nextjs-starter
```
And `tree` should display the full project structure, not just `package.json` + `package-lock.json`.

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test workflow to build local file URLs more consistently during matrix generation.
  * Improved handling for both random and full test combination generation, helping prevent URL formatting issues in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->