### PR TITLE
fix(ci): make lint, type-check, and build blocking in smoke-test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -51,7 +51,7 @@ jobs:
           npm install
           npm run format --if-present
           npm run lint:fix --if-present
-          npm run lint --if-present || echo "Lint warnings found (non-blocking)"
-          npm run type-check --if-present || echo "Type-check warnings found (non-blocking)"
-          SKIP_ENV_VALIDATION=true npm run build --if-present || echo "Build warnings found (non-blocking)"
+          npm run lint --if-present
+          npm run type-check --if-present
+          SKIP_ENV_VALIDATION=true npm run build --if-present
           echo "Smoke test passed for ${{ matrix.template }}"


### PR DESCRIPTION
## Problem

`smoke-test.yml` uses `|| echo` fallbacks on three critical checks, making them non-blocking on PRs:

```yaml
npm run lint --if-present || echo "Lint warnings found (non-blocking)"
npm run type-check --if-present || echo "Type-check warnings found (non-blocking)"
SKIP_ENV_VALIDATION=true npm run build --if-present || echo "Build warnings found (non-blocking)"
```

A PR that introduces a broken build, type errors, or lint errors in a scaffolded template passes the smoke-test check with ✅. The failure is swallowed and printed as an informational message.

`test-combinations.yml` (which runs on every push to `main`) already runs the same steps **without** fallbacks — they are strictly blocking there. This asymmetry means problems visible on main after merge are invisible before merge.

## Fix

Remove the `|| echo` fallbacks:

```yaml
npm run lint --if-present
npm run type-check --if-present
SKIP_ENV_VALIDATION=true npm run build --if-present
```

The `npm run format --if-present` and `npm run lint:fix --if-present` steps that run immediately before auto-fix any fixable issues, so the blocking lint check sees a clean state.

## Impact

- PRs that break lint, type-check, or build in a generated project are now blocked before merge
- Matches the strictness of `test-combinations.yml` on main

Closes #191