### PR TITLE
fix(jest): use triple-slash reference for @testing-library/jest-dom types

### DIFF
--- a/extensions/react-testing-library-with-jest/jest.setup.ts
+++ b/extensions/react-testing-library-with-jest/jest.setup.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+/// <reference types="@testing-library/jest-dom" />


### PR DESCRIPTION
## Problem

`react-vite-starter`'s `tsconfig.json` explicitly sets `"types": ["node"]`. When `types` is explicitly listed, TypeScript only loads those declared packages for global ambient type declarations. The `react-testing-library-with-jest` extension adds a `jest.setup.ts` that does:

```typescript
import '@testing-library/jest-dom';
```

This side-effect import triggers **TS2882**: *Cannot find module or type declarations for side-effect import of '@testing-library/jest-dom'* — because TypeScript can't locate the module's type declarations through the restricted type loading.

This was revealed by the scaffold URL fix (#202 / PR #203) which made CI test real generated projects instead of empty ones.

## Fix

Replace the module import with a TypeScript compiler directive:

```typescript
// Before
import '@testing-library/jest-dom';

// After  
/// <reference types="@testing-library/jest-dom" />
```

The triple-slash directive is a compiler instruction that loads type declarations directly, bypassing module resolution entirely. It is unaffected by the `"types"` array in tsconfig.

**File:** `extensions/react-testing-library-with-jest/jest.setup.ts`

Closes #206