### PR TITLE
fix(nestjs): change moduleResolution from node to bundler in tsconfig

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -15,7 +15,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "types": ["jest", "node"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"
   },


### PR DESCRIPTION
## Problem

`templates/nestjs-starter/tsconfig.json` uses `"moduleResolution": "node"` — the legacy Node.js resolution algorithm from TypeScript ≤4.x. This algorithm resolves modules by looking at `types`/`typings` fields in `package.json` or falling back to `index.d.ts`. It **does not support the `exports` field**.

Modern packages expose their TypeScript declarations exclusively via `package.json` exports:

| Package | Where types are declared |
|---|---|
| `drizzle-kit@0.31.8` | `exports["types"]` only |
| `drizzle-orm/node-postgres` | subpath export (`exports["./node-postgres"]`) |
| `pg` | `@types/pg` (works with either) |
| `@vendia/serverless-express` | `exports["types"]` only |
| `@nestjs/swagger` | `exports["types"]` |

With `"moduleResolution": "node"`, all of these fail with **TS2307: Cannot find module**.

This was revealed by PR #203 which fixed the broken scaffold URLs in `test-combinations.yml`, making CI test real generated projects.

## Fix

Change `"moduleResolution"` from `"node"` to `"bundler"` in `templates/nestjs-starter/tsconfig.json`.

`"bundler"` resolution:
- Supports the `exports` field for TypeScript type resolution ✅
- Compatible with `"module": "commonjs"` (used by NestJS) ✅
- Does not require file extensions on relative imports (unlike `node16`) ✅
- Available since TypeScript 5.0 ✅

**File changed:** `templates/nestjs-starter/tsconfig.json` — one line.

Closes #205