### PR TITLE
fix(apollo): update onError import for Apollo Client v4

### DIFF
--- a/extensions/react-apollo/src/lib/apollo-client.ts
+++ b/extensions/react-apollo/src/lib/apollo-client.ts
@@ -1,5 +1,4 @@
-import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
-import { onError } from '@apollo/client/link/error';
+import { ApolloClient, InMemoryCache, HttpLink, from, onError } from '@apollo/client';
 
 const httpLink = new HttpLink({
   uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT || '/api/graphql',


### PR DESCRIPTION
## Problem

The `react-apollo` extension uses `@apollo/client@^4.x` but its source code was written for the v3 API. In Apollo Client v3, error-handling links were published as separate subpath exports:

```typescript
import { onError } from '@apollo/client/link/error'; // v3
```

In **Apollo Client v4**, all link utilities were consolidated into the main package. The `@apollo/client/link/error` subpath **no longer exists**, causing:

```
src/lib/apollo-client.ts(2,25): error TS2307: Cannot find module '@apollo/client/link/error'
src/lib/apollo-client.ts(9,30): error TS7031: Binding element 'graphQLErrors' implicitly has an 'any' type
```

This was revealed by PR #203 which fixed the broken scaffold URLs in `test-combinations.yml`.

## Fix

Merge the two import lines into one — `onError` is now exported from `@apollo/client` directly:

```typescript
// Before (v3 API)
import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
import { onError } from '@apollo/client/link/error';

// After (v4 API)
import { ApolloClient, InMemoryCache, HttpLink, from, onError } from '@apollo/client';
```

**File changed:** `extensions/react-apollo/src/lib/apollo-client.ts` — 2 lines → 1 line.

Closes #206