### PR TITLE
feat: elevate template presentation and first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository contains official templates and extensions for [create-awesome-n
 
 ## Quick start
 
+Browse templates and extensions on the [official site](https://create-awesome-node-app.vercel.app), then scaffold locally:
+
 ```sh
 # Interactive mode
 npx create-awesome-node-app
@@ -85,6 +87,9 @@ If the user only says "continue" or asks "what should I do next", summarize the 
 
 ## Support
 
+- 🌐 [Official site](https://create-awesome-node-app.vercel.app)
+- 📚 [Templates](https://create-awesome-node-app.vercel.app/templates)
+- 🧩 [Extensions](https://create-awesome-node-app.vercel.app/extensions)
 - 📦 [NPM Package](https://www.npmjs.com/package/create-awesome-node-app)
 - 🐛 [Report Issues](https://github.com/Create-Node-App/cna-templates/issues)
 - 💬 [Discussions](https://github.com/Create-Node-App/cna-templates/discussions)

--- a/docs/DEFAULT_LANDING_DESIGN.md
+++ b/docs/DEFAULT_LANDING_DESIGN.md
@@ -292,7 +292,15 @@ Use a simple link with a label and an arrow. A shared `DocsLink` helper is optio
 
 ---
 
-## 10. Updating this system
+## 10. Catalog preview fields (deferred)
+
+The published catalog (`templates.json` + `templates.schema.json`) does **not** yet support preview or screenshot metadata. The schema uses `additionalProperties: false`, so extra keys would fail validation.
+
+Defer `preview` / `screenshot` fields until the website catalog can consume them. See [`DEFAULT_LANDING_GUIDE.md`](./DEFAULT_LANDING_GUIDE.md) §6 for the rollout steps. Do not break the schema to ship assets early.
+
+---
+
+## 11. Updating this system
 
 1. Propose token changes in a dedicated issue.
 2. Update `shared/assets/*` and this document.

--- a/docs/DEFAULT_LANDING_GUIDE.md
+++ b/docs/DEFAULT_LANDING_GUIDE.md
@@ -80,7 +80,13 @@ Respect `prefers-reduced-motion` by collapsing animation and transition duration
 
 ### CTAs
 
-Primary CTA should point to the main editable file of the template (e.g. `src/pages/Landing.tsx`, `src/app/page.tsx`). The secondary CTA should link to `./docs/README.md`.
+Primary and secondary CTAs must be useful in the browser. Prefer:
+
+1. **Read the docs** → `./docs/README.md` (or `/docs/README.md` when that path is served).
+2. **Run the app** → a non-link hint such as `npm run dev` (or the package-manager equivalent), not a dead file URL.
+3. **Template docs on the website** → `https://create-awesome-node-app.vercel.app/templates` when a third link is useful.
+
+Do **not** use primary CTAs that point at source paths like `src/app/page.tsx` or `app/routes/_index.tsx`. Those paths are not served by the dev server and look broken to users.
 
 ### Interpolation in `.template` files
 
@@ -102,7 +108,7 @@ className={`${styles.button} ${styles.buttonPrimary}`}
 |---|---|---|---|
 | `react-vite-starter` | `src/pages/Landing.tsx.template`, `Landing.css` | Plain CSS | Reference implementation |
 | `nextjs-starter` | `src/app/page.tsx.template`, `page.module.css`, `globals.css` | CSS Modules | Use `Image` with `unoptimized` for SVG; add `favicon.svg` to `src/app/` |
-| `nextjs-saas-ai-starter` | Brand component only | Existing design system | Full SaaS landing out of scope; align fallback logo only |
+| `nextjs-saas-ai-starter` | Brand component only | Existing product UI | Flagship showcase — see §9; nest mark as fallback logo only |
 | `remix-starter` | `app/routes/_index.tsx.template`, `app/styles/landing.css` | Plain CSS + import | Add `app/types/css.d.ts` for CSS side-effect imports |
 | `astro-starter` | `src/pages/index.astro` | Scoped global `<style>` | Copy SVG mark/favicon to `public/` |
 | `webextension-react-vite-starter` | `src/newtab/Newtab.tsx.template`, `src/popup/Popup.tsx.template` | Plain CSS | Keep popup compact; newtab can use full landing layout |
@@ -110,7 +116,23 @@ className={`${styles.button} ${styles.buttonPrimary}`}
 
 ---
 
-## 6. Testing checklist
+## 6. Preview / screenshot metadata (deferred)
+
+`templates.schema.json` sets `additionalProperties: false` on the catalog root and only allows the existing template fields (`name`, `slug`, `description`, `url`, `type`, `category`, `labels`).
+
+**Do not** add `preview`, `screenshot`, `ogImage`, or similar fields to `templates.json` until the website catalog can consume them and the schema is intentionally extended. Adding those keys today would fail validation and break consumers.
+
+When the site is ready:
+
+1. Extend `templates.schema.json` with optional preview fields.
+2. Wire the website catalog to render them.
+3. Then add URLs or asset paths to `templates.json`.
+
+Until then, keep catalog copy craft-forward in `description` only.
+
+---
+
+## 7. Testing checklist
 
 For every new or updated landing:
 
@@ -124,7 +146,7 @@ For every new or updated landing:
 
 ---
 
-## 7. Updating the system
+## 8. Updating the system
 
 1. Open an issue describing the change and affected templates.
 2. Update `shared/assets/` and `DEFAULT_LANDING_DESIGN.md` first.
@@ -134,7 +156,19 @@ For every new or updated landing:
 
 ---
 
-## 8. Related documents
+## 9. SaaS brand relationship (`nextjs-saas-ai-starter`)
+
+`nextjs-saas-ai-starter` is the flagship product showcase. It keeps its own marketing UI, design system, and landing narrative.
+
+Rules:
+
+- **Do not** force a full cozy-nest restyle of the SaaS landing.
+- Align only the **fallback nest mark** (and favicon source when needed) with `shared/assets/`.
+- Treat the SaaS template as a separate brand surface that still belongs to the CNA ecosystem, not as another copy of the default starter landing.
+
+---
+
+## 10. Related documents
 
 - [`DEFAULT_LANDING_DESIGN.md`](./DEFAULT_LANDING_DESIGN.md) — tokens, typography, motion, logo rules
 - [`docs/TESTING.md`](./TESTING.md) — local testing commands and CI details

--- a/templates.json
+++ b/templates.json
@@ -4,8 +4,8 @@
     {
       "slug": "frontend-applications",
       "name": "Frontend Applications",
-      "description": "Templates for building modern web interfaces.",
-      "details": "Discover templates for React, Vue, and other frontend frameworks to build beautiful user interfaces.",
+      "description": "Client-side and content-first starters for SPAs and static sites.",
+      "details": "Pick these when you need a browser UI without a full-stack framework — React + Vite for SPAs, Astro for content sites.",
       "labels": [
         "Frontend",
         "UI",
@@ -17,8 +17,8 @@
     {
       "slug": "backend-applications",
       "name": "Backend Applications",
-      "description": "Templates for building robust server-side applications.",
-      "details": "Explore templates for Node.js, Express, NestJS, and other backend frameworks to build powerful APIs.",
+      "description": "API and service starters for NestJS, Hono, and similar Node backends.",
+      "details": "Use when the deliverable is an HTTP API or worker — NestJS for modular services, Hono for lean edge/serverless handlers.",
       "labels": [
         "Backend",
         "API",
@@ -31,8 +31,8 @@
     {
       "slug": "fullstack-applications",
       "name": "Full Stack Applications",
-      "description": "Templates for building complete web applications.",
-      "details": "Find templates for Next.js, Remix, and other full stack frameworks to build end-to-end applications.",
+      "description": "Frameworks that own routing, rendering, and server logic in one app.",
+      "details": "Choose Next.js or React Router (Remix) when UI and server routes should live in the same codebase.",
       "labels": [
         "FullStack",
         "Frontend",
@@ -44,8 +44,8 @@
     {
       "slug": "monorepo-boilerplate",
       "name": "Monorepo Boilerplate",
-      "description": "Templates for managing multiple packages in a single repository.",
-      "details": "Streamline development with monorepo templates using tools like Nx, Turborepo, and Lerna for efficient code sharing.",
+      "description": "Multi-package workspaces with shared tooling and release flow.",
+      "details": "Start here when you need apps and packages in one repo with Turborepo pipelines and Changesets.",
       "labels": [
         "Monorepo",
         "Workspaces",
@@ -57,8 +57,8 @@
     {
       "slug": "user-acceptance-testing",
       "name": "User Acceptance Testing",
-      "description": "Templates with built-in testing frameworks for end-to-end validation.",
-      "details": "Ensure your applications meet user requirements with templates featuring Cypress, Playwright, or Selenium for comprehensive testing.",
+      "description": "Browser automation projects for end-to-end acceptance suites.",
+      "details": "Use when the repo itself is a WebdriverIO (or similar) test harness, not an application under test.",
       "labels": [
         "Testing",
         "End-to-End",
@@ -70,8 +70,8 @@
     {
       "slug": "web-extension",
       "name": "Web Extension",
-      "description": "Templates for building browser extensions and add-ons.",
-      "details": "Develop cross-browser extensions with templates that support Chrome, Firefox, and Edge with modern web technologies.",
+      "description": "Browser extension starters with React and Vite.",
+      "details": "Scaffold popup, options, and newtab surfaces that target Chrome, Firefox, and Edge via WebExtension APIs.",
       "labels": [
         "WebExtension",
         "Browser",
@@ -85,7 +85,7 @@
     {
       "name": "NestJS Boilerplate",
       "slug": "nestjs-boilerplate",
-      "description": "A boilerplate for building scalable and maintainable backend applications using NestJS with TypeScript, ESLint, and Prettier.",
+      "description": "Modular NestJS API with TypeScript, ESLint, and Prettier. Reach for it when you want controllers, providers, and clear module boundaries from day one.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/nestjs-starter",
       "type": "nestjs-backend",
       "category": "backend-applications",
@@ -102,7 +102,7 @@
     {
       "name": "NextJS Starter",
       "slug": "nextjs-starter",
-      "description": "A production-ready Next.js starter with TypeScript, ESLint, Prettier, and customizable options for rapid full-stack development.",
+      "description": "Next.js App Router starter with TypeScript and a feature-based layout. Use it for full-stack React apps that need server components, routes, and optional auth examples.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/nextjs-starter",
       "type": "nextjs",
       "category": "fullstack-applications",
@@ -113,13 +113,13 @@
         "ESLint",
         "Prettier",
         "Customizable",
-        "Production-ready"
+        "App Router"
       ]
     },
     {
       "name": "Turborepo Boilerplate",
       "slug": "turborepo-boilerplate",
-      "description": "A modern monorepo boilerplate with Turborepo, TypeScript, Changesets, and Workspaces for efficient multi-package management.",
+      "description": "Turborepo workspace with TypeScript, Changesets, and shared packages. Best when multiple apps share UI or config and you want pipeline caching.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/turborepo-starter",
       "type": "monorepo",
       "category": "monorepo-boilerplate",
@@ -136,7 +136,7 @@
     {
       "name": "React Vite Boilerplate",
       "slug": "react-vite-boilerplate",
-      "description": "A fast and lightweight React boilerplate with Vite, TypeScript, React Router, and modern tooling for frontend development.",
+      "description": "React SPA on Vite with React Router and TypeScript. Choose it for client-only apps where instant HMR and a lean build matter more than SSR.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/react-vite-starter",
       "type": "react",
       "category": "frontend-applications",
@@ -148,14 +148,14 @@
         "ESLint",
         "Prettier",
         "React Router",
-        "Fast",
-        "Lightweight"
+        "SPA",
+        "HMR"
       ]
     },
     {
       "name": "Web Extension React Boilerplate",
       "slug": "web-extension-react-boilerplate",
-      "description": "A boilerplate for building WebExtensions with React, Vite, TypeScript, and features like hot module replacement and polyfills.",
+      "description": "React + Vite WebExtension with HMR and polyfills. Use it for Chrome/Firefox/Edge extensions that share a React UI across popup and pages.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/webextension-react-vite-starter",
       "type": "webextension-react",
       "category": "web-extension",
@@ -173,7 +173,7 @@
     {
       "name": "WebdriverIO Boilerplate",
       "slug": "webdriverio-boilerplate",
-      "description": "A comprehensive WebdriverIO boilerplate with TypeScript, ESLint, Prettier, and Selenoid for automated user acceptance testing.",
+      "description": "WebdriverIO + TypeScript harness with Selenoid-friendly setup. Scaffold this when the project is an acceptance-test suite, not the app under test.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/wdio-starter",
       "type": "webdriverio",
       "category": "user-acceptance-testing",
@@ -190,7 +190,7 @@
     {
       "name": "NextJS SaaS AI Starter",
       "slug": "nextjs-saas-ai-starter",
-      "description": "A production-ready multi-tenant Next.js SaaS starter with AI (OpenAI/Anthropic), Auth.js v5, Drizzle ORM + PostgreSQL, Tailwind CSS v4, shadcn/ui, RBAC, audit logs, webhooks, and i18n.",
+      "description": "Multi-tenant Next.js SaaS with AI providers, Auth.js v5, Drizzle + PostgreSQL, Tailwind v4, shadcn/ui, RBAC, audit logs, webhooks, and i18n. The flagship product showcase — not a minimal starter.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/nextjs-saas-ai-starter",
       "type": "nextjs-saas-ai",
       "category": "fullstack-applications",
@@ -206,14 +206,13 @@
         "PostgreSQL",
         "Auth.js",
         "RBAC",
-        "i18n",
-        "Production-ready"
+        "i18n"
       ]
     },
     {
       "name": "Remix / React Router v7 Starter",
       "slug": "remix-starter",
-      "description": "A React Router v7 application with file-based routing, SSR, TypeScript, and modern React patterns for full-stack web apps.",
+      "description": "React Router v7 with file-based routes, loaders/actions, and TypeScript. Pick it when you want SSR and nested data routes without the Next.js App Router model.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/remix-starter",
       "type": "remix",
       "category": "fullstack-applications",
@@ -229,7 +228,7 @@
     {
       "name": "Astro Starter",
       "slug": "astro-starter",
-      "description": "An Astro site starter with static site generation, TypeScript, and component-based architecture for content-focused websites.",
+      "description": "Astro static site with TypeScript and island-friendly structure. Ideal for docs, marketing, and content sites that ship HTML first and hydrate only where needed.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/astro-starter",
       "type": "astro",
       "category": "frontend-applications",
@@ -244,7 +243,7 @@
     {
       "name": "Hono Starter",
       "slug": "hono-starter",
-      "description": "A lightweight Hono API starter with TypeScript support, ideal for edge computing, serverless, and small-to-medium APIs.",
+      "description": "Minimal Hono API in TypeScript. Use it for edge, serverless, or small HTTP services where NestJS would be heavier than you need.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/templates/hono-starter",
       "type": "hono",
       "category": "backend-applications",

--- a/templates/astro-starter/src/pages/index.astro
+++ b/templates/astro-starter/src/pages/index.astro
@@ -3,12 +3,36 @@
 const projectName = "<%= projectName %>";
 
 const features = [
-  { icon: "🚀", title: "Astro 7", description: "Fast static sites with partial hydration and content islands." },
-  { icon: "⚛️", title: "React-ready", description: "Add interactive islands with React, Preact, or Solid when needed." },
-  { icon: "🛡️", title: "TypeScript", description: "Type-safe components and pages out of the box." },
-  { icon: "📦", title: "Feature-based structure", description: "Organize components and pages as the project grows." },
-  { icon: "✨", title: "Static output", description: "Ship pre-rendered HTML with zero runtime by default." },
-  { icon: "🧩", title: "Addon ready", description: "Layer UI libraries, state tools, testing, and deployment." },
+  {
+    icon: "📄",
+    title: "HTML-first output",
+    description: "Ship pre-rendered pages by default — zero client JS until you opt in.",
+  },
+  {
+    icon: "🏝️",
+    title: "Content islands",
+    description: "Hydrate React, Preact, or Solid only on the interactive bits.",
+  },
+  {
+    icon: "🚀",
+    title: "Astro 7",
+    description: "File-based pages, content collections–ready structure, and fast builds.",
+  },
+  {
+    icon: "🛡️",
+    title: "TypeScript",
+    description: "Typed components and pages without a heavy SPA toolchain.",
+  },
+  {
+    icon: "📚",
+    title: "Docs & marketing fit",
+    description: "Ideal when the site is mostly content and a few interactive widgets.",
+  },
+  {
+    icon: "🧩",
+    title: "Addon surface",
+    description: "Layer UI, testing, or deployment extensions as the site grows.",
+  },
 ];
 
 const docs = [
@@ -27,7 +51,7 @@ const docs = [
     <title>{projectName} - Create Awesome Node App</title>
   </head>
   <body>
-    <div class="cna-landing">
+    <div class="cna-landing cna-landing--astro">
       <header class="cna-landing__header">
         <img src="/logo.svg" alt="Create Awesome Node App" class="cna-landing__logo" width="40" height="40" />
         <span class="cna-landing__brand">Create Awesome Node App</span>
@@ -35,19 +59,30 @@ const docs = [
 
       <main class="cna-landing__main">
         <section class="cna-landing__hero" style="--index: 0">
-          <span class="cna-landing__eyebrow">Your project is ready</span>
+          <span class="cna-landing__eyebrow">Astro · static-first</span>
           <h1 class="cna-landing__title">{projectName}</h1>
           <p class="cna-landing__lead">
-            A cozy Astro starter with static-first performance and a feature-based foundation.
+            Content-first Astro with islands when you need them. Choose this for docs, marketing, and sites that
+            should ship HTML before JavaScript.
           </p>
           <div class="cna-landing__actions">
-            <a href="/src/pages/index.astro" class="cna-landing__button cna-landing__button--primary">Start editing</a>
-            <a href="./docs/README.md" class="cna-landing__button cna-landing__button--secondary">Read the docs</a>
+            <a href="./docs/README.md" class="cna-landing__button cna-landing__button--primary">Read the docs</a>
+            <span class="cna-landing__button cna-landing__button--secondary">
+              Run <code class="cna-landing__code">npm run dev</code>
+            </span>
+            <a
+              href="https://create-awesome-node-app.vercel.app/templates"
+              class="cna-landing__button cna-landing__button--ghost"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Template docs
+            </a>
           </div>
         </section>
 
         <section class="cna-landing__features">
-          <h2 class="cna-landing__section-title">What is inside</h2>
+          <h2 class="cna-landing__section-title">Built for content sites</h2>
           <div class="cna-landing__grid">
             {
               features.map((feature, index) => (
@@ -146,6 +181,22 @@ const docs = [
     line-height: 1.65;
   }
 
+  /* Astro: soft dual glow + bottom accent (content / islands) */
+  .cna-landing--astro {
+    background:
+      radial-gradient(ellipse 80% 35% at 50% -5%, rgba(251, 191, 36, 0.14), transparent 50%),
+      radial-gradient(circle at 70% 100%, rgba(20, 184, 166, 0.14), transparent 40%),
+      var(--cna-bg);
+  }
+
+  .cna-landing--astro .cna-landing__hero {
+    border-bottom: 3px solid var(--cna-amber-soft);
+  }
+
+  .cna-landing--astro .cna-landing__card-icon {
+    background: rgba(251, 191, 36, 0.14);
+  }
+
   .cna-landing__header {
     display: flex;
     align-items: center;
@@ -230,12 +281,23 @@ const docs = [
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     padding: 0.75rem 1.25rem;
     border-radius: 0.75rem;
     font-weight: 700;
     font-size: 0.9375rem;
     text-decoration: none;
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  }
+
+  .cna-landing__code {
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.375rem;
+    background: rgba(0, 0, 0, 0.25);
+    font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 0.8125rem;
+    font-weight: 600;
   }
 
   .cna-landing__button:hover {
@@ -261,6 +323,17 @@ const docs = [
 
   .cna-landing__button--secondary:hover {
     background: var(--cna-border);
+  }
+
+  .cna-landing__button--ghost {
+    background: transparent;
+    color: var(--cna-teal);
+    border: 1px solid var(--cna-border);
+  }
+
+  .cna-landing__button--ghost:hover {
+    border-color: var(--cna-teal);
+    background: rgba(20, 184, 166, 0.08);
   }
 
   .cna-landing__section-title {

--- a/templates/hono-starter/README.md.template
+++ b/templates/hono-starter/README.md.template
@@ -1,8 +1,12 @@
 # <%= projectName %>
 
-A Hono application created with [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app).
+Welcome — this is a **Hono API** scaffolded with [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app).
 
-## Getting Started
+A lean TypeScript HTTP service for edge, serverless, or small APIs. No fake web UI — start the server and call the routes.
+
+Browse templates and extensions: [create-awesome-node-app.vercel.app](https://create-awesome-node-app.vercel.app)
+
+## Next commands
 
 ```bash
 <%= installCommand %>
@@ -11,14 +15,14 @@ A Hono application created with [create-awesome-node-app](https://www.npmjs.com/
 
 The server starts on [http://localhost:3000](http://localhost:3000).
 
-## Available Scripts
+## Available scripts
 
-- `<%= runCommand %> dev` — start the development server with hot reload
+- `<%= runCommand %> dev` — development server with hot reload
 - `<%= runCommand %> build` — compile TypeScript
-- `<%= runCommand %> start` — start the production server
-- `<%= runCommand %> format` — format code with Prettier
-- `<%= runCommand %> lint` — lint code with ESLint
-- `<%= runCommand %> type-check` — run TypeScript type checking
+- `<%= runCommand %> start` — production server
+- `<%= runCommand %> format` — format with Prettier
+- `<%= runCommand %> lint` — lint with ESLint
+- `<%= runCommand %> type-check` — TypeScript type checking
 
 ## Endpoints
 

--- a/templates/nestjs-starter/README.md.template
+++ b/templates/nestjs-starter/README.md.template
@@ -1,33 +1,12 @@
-# NestJS API
+# <%= projectName %>
 
-This project is a NestJS API generated using [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app). However, it is recommended to generate your own project using the command and following the options in the interactive menu. Please refer to the documentation for more information.
+Welcome — this is a **NestJS API** scaffolded with [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app).
 
-## Features
+You get a modular TypeScript service (controllers, providers, modules) ready for HTTP APIs. There is no web UI here; start the server and hit your routes.
 
-- 🦾 [TypeScript](https://www.typescriptlang.org/) - Ensures type safety
-- 🚀 NestJS Framework - Utilize the power of NestJS for efficient development
-- 💾 Database Integration - Connect to databases like MongoDB or PostgreSQL
-- 🔒 Validation and Error Handling - Handle user input validation and error responses
-- ⚙️ Configuration Management - Manage different environments and configurations
-- 📜 Logging - Implement logging for debugging and monitoring purposes
-- 📄 API Documentation - Generate API documentation using Swagger or OpenAPI
-- 🧪 Unit Testing - Write and execute unit tests to ensure code quality
+Browse templates and extensions: [create-awesome-node-app.vercel.app](https://create-awesome-node-app.vercel.app)
 
-## Extra documentation
-
-You can find useful information such as project structure, available scripts and much more in the [docs](./docs) folder!
-
-## Pre-packed with
-
-### Development Tools
-
-- [TypeScript](https://www.typescriptlang.org/)
-- [ESLint](https://eslint.org/) - JavaScript and JSX linting utility
-- [Prettier](https://prettier.io/) - Opinionated code formatter
-- [Husky](https://www.npmjs.com/package/husky) - Simplifies Git hooks setup
-- [lint-staged](https://www.npmjs.com/package/lint-staged) - Runs linters against staged git files, preventing 💩 from slipping into your code base!
-
-## Quickstart
+## Next commands
 
 ```sh
 fnm use
@@ -35,7 +14,7 @@ fnm use
 <%= runCommand%> dev
 ```
 
-or using Docker and Docker Compose (_recommended_):
+Or with Docker Compose:
 
 ```sh
 fnm use
@@ -43,26 +22,28 @@ fnm use
 <%= runCommand%> compose:up
 ```
 
-## Development
+## Features
 
-While developing, you will mostly rely on `<%= runCommand%> dev`; however, there are additional scripts available:
+- TypeScript, ESLint, and Prettier configured
+- NestJS module layout for clear boundaries
+- Ready for database, OpenAPI, and serverless addons
+- Logging and config patterns suited to API work
 
-| `<%= runCommand%> <script>` | Description                                                                                                             |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `dev`                       | Serves your app locally for development                                                                                 |
-| `format`                    | Formats the project using [Prettier](https://prettier.io/)                                                              |
-| `lint`                      | Lints the project for potential errors                                                                                   |
-| `lint:fix`                  | Lints the project and fixes all correctable errors                                                                       |
+## Extra documentation
 
-## Production
+Project structure, scripts, and conventions live in the [docs](./docs) folder.
 
-Available scripts:
+## Available scripts
 
-| `<%= runCommand%> <script>` | Description                                                                                                 |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `preview`                   | Serves your app using your production-ready setup                                                           |
-| `build`                     | Builds the application to the `dist/` directory                                                              |
+| `<%= runCommand%> <script>` | Description |
+| --------------------------- | ----------- |
+| `dev` | Serve locally for development |
+| `format` | Format with Prettier |
+| `lint` | Lint for potential errors |
+| `lint:fix` | Lint and fix correctable issues |
+| `build` | Build to `dist/` |
+| `preview` | Serve the production build |
 
 ## Contributing
 
-Read [CONTRIBUTING.md](./CONTRIBUTING.md) for local development, branching and module conventions. For template improvements open issues / PRs in [Create-Node-App/cna-templates](https://github.com/Create-Node-App/cna-templates).
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) for local development and module conventions. For template improvements, open issues or PRs in [Create-Node-App/cna-templates](https://github.com/Create-Node-App/cna-templates).

--- a/templates/nextjs-starter/[src]/app/page.module.css
+++ b/templates/nextjs-starter/[src]/app/page.module.css
@@ -15,6 +15,23 @@
   flex-direction: column;
 }
 
+/* Next.js: teal-forward accent (server + App Router) */
+.landingNext {
+  background:
+    radial-gradient(ellipse 65% 45% at 85% 5%, rgba(20, 184, 166, 0.2), transparent 55%),
+    radial-gradient(circle at 10% 90%, rgba(13, 148, 136, 0.12), transparent 45%),
+    var(--cna-bg);
+}
+
+.landingNext .hero {
+  border-top: 3px solid var(--cna-teal);
+}
+
+.landingNext .cardIcon {
+  background: rgba(20, 184, 166, 0.16);
+  color: var(--cna-teal);
+}
+
 .header {
   display: flex;
   align-items: center;
@@ -133,6 +150,26 @@
 
 .buttonSecondary:hover {
   background: var(--cna-border);
+}
+
+.buttonGhost {
+  background: transparent;
+  color: var(--cna-teal);
+  border: 1px solid var(--cna-border);
+}
+
+.buttonGhost:hover {
+  border-color: var(--cna-teal);
+  background: rgba(20, 184, 166, 0.08);
+}
+
+.code {
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.375rem;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.8125rem;
+  font-weight: 600;
 }
 
 .sectionTitle {

--- a/templates/nextjs-starter/[src]/app/page.tsx
+++ b/templates/nextjs-starter/[src]/app/page.tsx
@@ -4,28 +4,33 @@ import styles from "./page.module.css";
 const features = [
   {
     icon: "▲",
-    title: "Next.js 16 App Router",
-    description: "File-system routing, layouts, and latest React features out of the box.",
+    title: "App Router first",
+    description: "Layouts, nested routes, and React Server Components without a pages/ rewrite.",
+  },
+  {
+    icon: "🖥️",
+    title: "Server + client",
+    description: "Keep data close to the server; hydrate interactive islands only where needed.",
   },
   {
     icon: "🛡️",
-    title: "TypeScript + ESLint + Prettier",
-    description: "Static typing and consistent, automated code style.",
-  },
-  {
-    icon: "📦",
-    title: "Feature-based structure",
-    description: "Scale by co-locating routes, state, and components.",
+    title: "TypeScript + lint",
+    description: "ESLint and Prettier configured so full-stack changes stay consistent.",
   },
   {
     icon: "🔐",
-    title: "Login example",
-    description: "A ready-made auth route to kickstart protected flows.",
+    title: "Auth route sample",
+    description: "A login example under (auth) so protected flows have a starting point.",
+  },
+  {
+    icon: "📦",
+    title: "Feature folders",
+    description: "Grow by co-locating routes, UI, and domain logic per feature.",
   },
   {
     icon: "🧩",
-    title: "Addon ready",
-    description: "Layer UI libraries, state tools, testing, and deployment.",
+    title: "Addon surface",
+    description: "Add Tailwind, Auth.js, Drizzle, tRPC, or i18n when the product needs them.",
   },
 ];
 
@@ -38,7 +43,7 @@ const docs = [
 
 export default function Home() {
   return (
-    <div className={styles.landing}>
+    <div className={`${styles.landing} ${styles.landingNext}`}>
       <header className={styles.header}>
         <Image
           src="/logo.svg"
@@ -53,24 +58,32 @@ export default function Home() {
 
       <main className={styles.main}>
         <section className={styles.hero} style={{ "--index": 0 } as React.CSSProperties}>
-          <span className={styles.eyebrow}>Your project is ready</span>
+          <span className={styles.eyebrow}>Next.js App Router</span>
           <h1 className={styles.title}>Next.js Starter</h1>
           <p className={styles.lead}>
-            A cozy Next.js starter with a feature-based foundation. Everything you need to start building your next
-            page.
+            A full-stack Next.js foundation with server components and feature folders. Choose it when UI and
+            server routes should live in one App Router codebase.
           </p>
           <div className={styles.actions}>
-            <a href="src/app/page.tsx" className={`${styles.button} ${styles.buttonPrimary}`}>
-              Start editing
-            </a>
-            <a href="./docs/README.md" className={`${styles.button} ${styles.buttonSecondary}`}>
+            <a href="./docs/README.md" className={`${styles.button} ${styles.buttonPrimary}`}>
               Read the docs
+            </a>
+            <span className={`${styles.button} ${styles.buttonSecondary}`}>
+              Run <code className={styles.code}>npm run dev</code>
+            </span>
+            <a
+              href="https://create-awesome-node-app.vercel.app/templates"
+              className={`${styles.button} ${styles.buttonGhost}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Template docs
             </a>
           </div>
         </section>
 
         <section className={styles.features}>
-          <h2 className={styles.sectionTitle}>What is inside</h2>
+          <h2 className={styles.sectionTitle}>Built for App Router apps</h2>
           <div className={styles.grid}>
             {features.map((feature, index) => (
               <article

--- a/templates/nextjs-starter/[src]/app/page.tsx.template
+++ b/templates/nextjs-starter/[src]/app/page.tsx.template
@@ -4,28 +4,33 @@ import styles from "./page.module.css";
 const features = [
   {
     icon: "▲",
-    title: "Next.js 16 App Router",
-    description: "File-system routing, layouts, and latest React features out of the box.",
+    title: "App Router first",
+    description: "Layouts, nested routes, and React Server Components without a pages/ rewrite.",
+  },
+  {
+    icon: "🖥️",
+    title: "Server + client",
+    description: "Keep data close to the server; hydrate interactive islands only where needed.",
   },
   {
     icon: "🛡️",
-    title: "TypeScript + ESLint + Prettier",
-    description: "Static typing and consistent, automated code style.",
-  },
-  {
-    icon: "📦",
-    title: "Feature-based structure",
-    description: "Scale by co-locating routes, state, and components.",
+    title: "TypeScript + lint",
+    description: "ESLint and Prettier configured so full-stack changes stay consistent.",
   },
   {
     icon: "🔐",
-    title: "Login example",
-    description: "A ready-made auth route to kickstart protected flows.",
+    title: "Auth route sample",
+    description: "A login example under (auth) so protected flows have a starting point.",
+  },
+  {
+    icon: "📦",
+    title: "Feature folders",
+    description: "Grow by co-locating routes, UI, and domain logic per feature.",
   },
   {
     icon: "🧩",
-    title: "Addon ready",
-    description: "Layer UI libraries, state tools, testing, and deployment.",
+    title: "Addon surface",
+    description: "Add Tailwind, Auth.js, Drizzle, tRPC, or i18n when the product needs them.",
   },
 ];
 
@@ -40,7 +45,7 @@ const withIndex = (index: number) => ({ "--index": index }) as React.CSSProperti
 
 export default function Home() {
   return (
-    <div className={styles.landing}>
+    <div className={styles.landing + " " + styles.landingNext}>
       <header className={styles.header}>
         <Image
           src="/logo.svg"
@@ -55,24 +60,32 @@ export default function Home() {
 
       <main className={styles.main}>
         <section className={styles.hero} style={withIndex(0)}>
-          <span className={styles.eyebrow}>Your project is ready</span>
+          <span className={styles.eyebrow}>Next.js App Router</span>
           <h1 className={styles.title}><%= projectName %></h1>
           <p className={styles.lead}>
-            A cozy Next.js starter with a feature-based foundation. Everything you need to start building your next
-            page.
+            A full-stack Next.js foundation with server components and feature folders. Choose it when UI and
+            server routes should live in one App Router codebase.
           </p>
           <div className={styles.actions}>
-            <a href="/<%= srcDir %>/app/page.tsx" className={styles.button + " " + styles.buttonPrimary}>
-              Start editing
-            </a>
-            <a href="/docs/README.md" className={styles.button + " " + styles.buttonSecondary}>
+            <a href="/docs/README.md" className={styles.button + " " + styles.buttonPrimary}>
               Read the docs
+            </a>
+            <span className={styles.button + " " + styles.buttonSecondary}>
+              Run <code className={styles.code}>npm run dev</code>
+            </span>
+            <a
+              href="https://create-awesome-node-app.vercel.app/templates"
+              className={styles.button + " " + styles.buttonGhost}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Template docs
             </a>
           </div>
         </section>
 
         <section className={styles.features}>
-          <h2 className={styles.sectionTitle}>What is inside</h2>
+          <h2 className={styles.sectionTitle}>Built for App Router apps</h2>
           <div className={styles.grid}>
             {features.map((feature, index) => (
               <article

--- a/templates/react-vite-starter/[src]/pages/Landing.css
+++ b/templates/react-vite-starter/[src]/pages/Landing.css
@@ -56,6 +56,22 @@
   line-height: 1.65;
 }
 
+/* React Vite: warm amber-forward glow (SPA / HMR energy) */
+.cna-landing--react-vite {
+  background:
+    radial-gradient(ellipse 70% 50% at 15% 0%, rgba(245, 158, 11, 0.22), transparent 55%),
+    radial-gradient(circle at 90% 85%, rgba(217, 119, 6, 0.12), transparent 45%),
+    var(--cna-bg);
+}
+
+.cna-landing--react-vite .cna-landing__hero {
+  border-top: 3px solid var(--cna-amber);
+}
+
+.cna-landing--react-vite .cna-landing__card-icon {
+  background: rgba(245, 158, 11, 0.18);
+}
+
 .cna-landing__header {
   display: flex;
   align-items: center;
@@ -182,6 +198,17 @@
 
 .cna-landing__button--secondary:hover {
   background: var(--cna-border);
+}
+
+.cna-landing__button--ghost {
+  background: transparent;
+  color: var(--cna-teal);
+  border: 1px solid var(--cna-border);
+}
+
+.cna-landing__button--ghost:hover {
+  border-color: var(--cna-teal);
+  background: rgba(20, 184, 166, 0.08);
 }
 
 .cna-landing__section-title {

--- a/templates/react-vite-starter/[src]/pages/Landing.tsx.template
+++ b/templates/react-vite-starter/[src]/pages/Landing.tsx.template
@@ -10,33 +10,33 @@ interface Feature {
 const features: Feature[] = [
   {
     icon: '⚡',
-    title: 'Vite 8',
-    description: 'Instant HMR and a fast, opinionated build pipeline.',
+    title: 'Vite-native HMR',
+    description: 'Edit a component and see it update in milliseconds — no full reload tax.',
   },
   {
     icon: '⚛️',
-    title: 'React 19',
-    description: 'Latest React with modern patterns and future-ready APIs.',
+    title: 'React 19 SPA',
+    description: 'Client-rendered React with modern hooks and a lean runtime footprint.',
   },
   {
     icon: '🧭',
     title: 'React Router 7',
-    description: 'Client-side routing already wired for nested routes.',
+    description: 'Nested client routes already wired so you can grow screens without a rewrite.',
   },
   {
     icon: '🛡️',
-    title: 'TypeScript + ESLint + Prettier',
-    description: 'Static typing and consistent, automated code style.',
+    title: 'TypeScript + lint',
+    description: 'ESLint and Prettier ship configured so style debates stay out of PRs.',
   },
   {
     icon: '📦',
-    title: 'Feature-based structure',
-    description: 'Scale by co-locating routes, state, and components.',
+    title: 'Feature folders',
+    description: 'Co-locate routes, state, and UI per feature as the SPA grows.',
   },
   {
     icon: '🧩',
-    title: 'Addon ready',
-    description: 'Layer UI libraries, state tools, testing, and deployment.',
+    title: 'Addon surface',
+    description: 'Layer UI kits, state libraries, tests, or Electron when you need them.',
   },
 ];
 
@@ -50,7 +50,7 @@ const docs = [
 const withIndex = (index: number) => ({ '--index': index }) as React.CSSProperties;
 
 const Landing = () => (
-  <div className="cna-landing">
+  <div className="cna-landing cna-landing--react-vite">
     <header className="cna-landing__header">
       <img src="/logo.svg" alt="Create Awesome Node App" className="cna-landing__logo" width="40" height="40" />
       <span className="cna-landing__brand">Create Awesome Node App</span>
@@ -58,24 +58,32 @@ const Landing = () => (
 
     <main className="cna-landing__main">
       <section className="cna-landing__hero" style={withIndex(0)}>
-        <span className="cna-landing__eyebrow">Your project is ready</span>
+        <span className="cna-landing__eyebrow">React + Vite</span>
         <h1 className="cna-landing__title"><%= projectName %></h1>
         <p className="cna-landing__lead">
-          A cozy React + Vite starter with a feature-based foundation. Everything you need to start building your next
-          screen.
+          A client-side React SPA tuned for instant HMR. Reach for this when you want a fast browser app without
+          server rendering in the critical path.
         </p>
         <div className="cna-landing__actions">
-          <span className="cna-landing__button cna-landing__button--primary">
-            Start editing <code className="cna-landing__code"><%= srcDir %>/pages/Landing.tsx</code>
-          </span>
-          <a href="/docs/README.md" className="cna-landing__button cna-landing__button--secondary">
+          <a href="/docs/README.md" className="cna-landing__button cna-landing__button--primary">
             Read the docs
+          </a>
+          <span className="cna-landing__button cna-landing__button--secondary">
+            Run <code className="cna-landing__code">npm run dev</code>
+          </span>
+          <a
+            href="https://create-awesome-node-app.vercel.app/templates"
+            className="cna-landing__button cna-landing__button--ghost"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Template docs
           </a>
         </div>
       </section>
 
       <section className="cna-landing__features">
-        <h2 className="cna-landing__section-title">What is inside</h2>
+        <h2 className="cna-landing__section-title">Built for SPA velocity</h2>
         <div className="cna-landing__grid">
           {features.map((feature, index) => (
             <article key={feature.title} className="cna-landing__card" style={withIndex(index + 1)}>

--- a/templates/remix-starter/app/routes/_index.tsx.template
+++ b/templates/remix-starter/app/routes/_index.tsx.template
@@ -1,12 +1,36 @@
 import type { MetaFunction } from "react-router";
 
 const features = [
-  { icon: "🧭", title: "React Router v7", description: "Modern data APIs and fast client-side navigation." },
-  { icon: "⚛️", title: "React 19", description: "Latest React with modern patterns and future-ready APIs." },
-  { icon: "🛡️", title: "TypeScript", description: "Static typing across routes and components." },
-  { icon: "⚡", title: "Vite", description: "Fast builds and instant HMR for rapid development." },
-  { icon: "📦", title: "Feature-based structure", description: "Scale by co-locating routes, state, and components." },
-  { icon: "🧩", title: "Addon ready", description: "Layer UI libraries, state tools, testing, and deployment." },
+  {
+    icon: "🧭",
+    title: "Loaders & actions",
+    description: "Fetch and mutate on the route — data APIs stay next to the UI that needs them.",
+  },
+  {
+    icon: "📄",
+    title: "File-based routes",
+    description: "Nested layouts and URL segments map to files under app/routes.",
+  },
+  {
+    icon: "🌐",
+    title: "SSR by default",
+    description: "Ship HTML from the server, then hydrate for interactive navigation.",
+  },
+  {
+    icon: "⚛️",
+    title: "React 19",
+    description: "Modern React patterns on top of React Router v7 conventions.",
+  },
+  {
+    icon: "⚡",
+    title: "Vite builds",
+    description: "Fast local HMR and production bundles without a custom bundler setup.",
+  },
+  {
+    icon: "🧩",
+    title: "Addon surface",
+    description: "Layer UI, state, and testing extensions when the product grows.",
+  },
 ];
 
 const docs = [
@@ -22,7 +46,7 @@ export const meta: MetaFunction = () => {
 
 export default function Home() {
   return (
-    <div className="cna-landing">
+    <div className="cna-landing cna-landing--remix">
       <header className="cna-landing__header">
         <img src="/logo.svg" alt="Create Awesome Node App" className="cna-landing__logo" width="40" height="40" />
         <span className="cna-landing__brand">Create Awesome Node App</span>
@@ -30,24 +54,32 @@ export default function Home() {
 
       <main className="cna-landing__main">
         <section className="cna-landing__hero" style={{ "--index": 0 } as React.CSSProperties}>
-          <span className="cna-landing__eyebrow">Your project is ready</span>
+          <span className="cna-landing__eyebrow">React Router v7</span>
           <h1 className="cna-landing__title"><%= projectName %></h1>
           <p className="cna-landing__lead">
-            A cozy React Router starter with feature-based folders. Everything you need to start building your next
-            route.
+            Nested routes with loaders and actions — SSR without the Next.js App Router model. Pick this when
+            route-centric data loading is the mental model you want.
           </p>
           <div className="cna-landing__actions">
-            <a href="/app/routes/_index.tsx" className="cna-landing__button cna-landing__button--primary">
-              Start editing
-            </a>
-            <a href="./docs/README.md" className="cna-landing__button cna-landing__button--secondary">
+            <a href="./docs/README.md" className="cna-landing__button cna-landing__button--primary">
               Read the docs
+            </a>
+            <span className="cna-landing__button cna-landing__button--secondary">
+              Run <code className="cna-landing__code">npm run dev</code>
+            </span>
+            <a
+              href="https://create-awesome-node-app.vercel.app/templates"
+              className="cna-landing__button cna-landing__button--ghost"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Template docs
             </a>
           </div>
         </section>
 
         <section className="cna-landing__features">
-          <h2 className="cna-landing__section-title">What is inside</h2>
+          <h2 className="cna-landing__section-title">Built for route-centric apps</h2>
           <div className="cna-landing__grid">
             {features.map((feature, index) => (
               <article

--- a/templates/remix-starter/app/styles/landing.css
+++ b/templates/remix-starter/app/styles/landing.css
@@ -55,6 +55,23 @@
   line-height: 1.65;
 }
 
+/* Remix / RR v7: split amber–teal glow (nested routes / SSR) */
+.cna-landing--remix {
+  background:
+    radial-gradient(ellipse 50% 40% at 0% 30%, rgba(245, 158, 11, 0.18), transparent 50%),
+    radial-gradient(ellipse 50% 40% at 100% 70%, rgba(20, 184, 166, 0.16), transparent 50%),
+    var(--cna-bg);
+}
+
+.cna-landing--remix .cna-landing__hero {
+  border-left: 3px solid var(--cna-amber);
+  border-right: 3px solid var(--cna-teal);
+}
+
+.cna-landing--remix .cna-landing__card-icon {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.16), rgba(20, 184, 166, 0.16));
+}
+
 .cna-landing__header {
   display: flex;
   align-items: center;
@@ -139,12 +156,23 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   padding: 0.75rem 1.25rem;
   border-radius: 0.75rem;
   font-weight: 700;
   font-size: 0.9375rem;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.cna-landing__code {
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.375rem;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.8125rem;
+  font-weight: 600;
 }
 
 .cna-landing__button:hover {
@@ -170,6 +198,17 @@
 
 .cna-landing__button--secondary:hover {
   background: var(--cna-border);
+}
+
+.cna-landing__button--ghost {
+  background: transparent;
+  color: var(--cna-teal);
+  border: 1px solid var(--cna-border);
+}
+
+.cna-landing__button--ghost:hover {
+  border-color: var(--cna-teal);
+  background: rgba(20, 184, 166, 0.08);
 }
 
 .cna-landing__section-title {


### PR DESCRIPTION
## Summary
- Differentiate React/Next/Remix/Astro default landings beyond the shared formula
- Improve first-run CTAs to real next actions; rewrite `templates.json` blurbs
- Link the official website from README; brand Nest/Hono README welcomes
- Document deferred preview metadata and SaaS flagship brand relationship

## Related
- Closes #194
- Closes #195
- Closes #196
- Closes #197
- Closes #198
- Closes #199
- Closes #200
- Closes #201
- Builds on closed #164 foundation
- Cross-repo: Create-Node-App/website#6, Create-Node-App/create-node-app#207, Create-Node-App/.github#6

## Test plan
- [ ] `templates.json` still validates against schema
- [ ] Spot-check React Vite / Next / Remix / Astro landings for stack-specific copy and working CTAs
- [ ] Nest/Hono README templates include branded welcome + next commands
- [ ] README Support links to the official site
- [ ] No schema-breaking preview fields added


Made with [Cursor](https://cursor.com)