### PR TITLE
fix(nestjs): use node16 moduleResolution instead of bundler

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -15,7 +15,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "types": ["jest", "node"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"
   },


### PR DESCRIPTION
## Problem

The previous fix (#208) changed `"moduleResolution"` from `"node"` to `"bundler"` in `templates/nestjs-starter/tsconfig.json`. While this resolved drizzle-kit, pg, and @nestjs/swagger errors, `bundler` is the wrong choice for NestJS.

**Why `bundler` fails for NestJS with TypeScript 6:**

`"moduleResolution": "bundler"` is designed for Vite/webpack/esbuild environments. When paired with `"module": "commonjs"` (which NestJS requires) in TypeScript 6, bundler resolution silently fails to resolve packages that publish CommonJS types under the `"require"` condition in their `exports` field. Specifically:

- `@nestjs/mongoose@11.x` — publishes types under `"require"` condition
- `@vendia/serverless-express@4.x` — same pattern

**Why `node16` works instead:**

`"moduleResolution": "node16"` is specifically designed for Node.js runtimes (which NestJS is). With `"module": "commonjs"`, it resolves module exports using the `"require"` condition — exactly what these packages publish. `"ignoreDeprecations": "6.0"` already in the tsconfig suppresses the TypeScript 6 warning about this pairing.

## Fix

`"moduleResolution": "bundler"` → `"moduleResolution": "node16"` in `templates/nestjs-starter/tsconfig.json`.

Closes #205 (follow-up to #208)