### PR TITLE
fix(jest): fix @testing-library/jest-dom type resolution for TypeScript 6

### DIFF
--- a/extensions/react-testing-library-with-jest/jest.config.js.template
+++ b/extensions/react-testing-library-with-jest/jest.config.js.template
@@ -15,7 +15,9 @@ module.exports = {
   // Jest transformations
   // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
   transform: {
-    '^.+\\.tsx?$': 'ts-jest', // Transform TypeScript files using ts-jest
+    // ts-jest adds "@testing-library/jest-dom" to types so the import in
+    // jest.setup.ts is recognised without modifying the project tsconfig.
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { types: ['jest', 'node', '@testing-library/jest-dom'] } }],
   },
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed

--- a/extensions/react-testing-library-with-jest/jest.setup.ts
+++ b/extensions/react-testing-library-with-jest/jest.setup.ts
@@ -2,4 +2,5 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-/// <reference types="@testing-library/jest-dom" />
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('@testing-library/jest-dom');


### PR DESCRIPTION
## Problem

Templates using `"types": ["node"]` in `tsconfig.json` (like `react-vite-starter`) block TypeScript's global type discovery. This prevents `@testing-library/jest-dom` from being recognised:

- Previous attempt with `import '@testing-library/jest-dom'` → **TS2882** (side-effect import not recognised)
- Previous attempt with `/// <reference types="@testing-library/jest-dom" />` → **TS2688** (type definition file not found, because triple-slash references look in `typeRoots` which defaults to `node_modules/@types/`, and `@testing-library/jest-dom` is not there)

Both errors surface during `npm run type-check` because `jest.setup.ts` is included in the main tsconfig compilation scope.

## Fix: two coordinated changes

### 1. `jest.setup.ts` — use `require()` instead of `import`

```typescript
// eslint-disable-next-line @typescript-eslint/no-require-imports
require('@testing-library/jest-dom');
```

TypeScript does not resolve type declarations for `require()` calls, so no TS error during `tsc --noEmit`. Jest runs in CJS mode via ts-jest, so `require()` works correctly at runtime and sets up the matchers.

### 2. `jest.config.js.template` — pass inline tsconfig to ts-jest

```js
transform: {
  '^.+\\.tsx?$': ['ts-jest', { tsconfig: { types: ['jest', 'node', '@testing-library/jest-dom'] } }],
},
```

ts-jest uses this inline config (not the project tsconfig) when compiling test files. Adding `@testing-library/jest-dom` to `types` here loads the type augmentations for Jest matchers, making `expect(el).toHaveTextContent(...)` properly typed in tests — without touching the project's main `tsconfig.json`.

Closes #206 (follow-up to #207)