### PR TITLE
fix(tsconfig): fix TypeScript 6 compatibility in nestjs and react-vite templates

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,

--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -14,7 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node"],
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }


### PR DESCRIPTION
## Two coordinated tsconfig fixes for TypeScript 6.0 compatibility

Both templates use TypeScript `^6.0.3` which introduced stricter module resolution requirements.

---

### Fix 1 — `templates/nestjs-starter/tsconfig.json`

Change `"module": "commonjs"` → `"module": "node16"`

**Why:** TypeScript 6.0 made TS5110 a hard error: `"module" must be set to "Node16" when "moduleResolution" is "Node16"`. The previous fix (`moduleResolution: node16`) worked in TypeScript 5.x but fails in TypeScript 6.

For NestJS without `"type": "module"` in `package.json`, TypeScript still compiles all files as CommonJS even with `"module": "node16"`. The resolution algorithm now correctly finds `@nestjs/mongoose`, `@vendia/serverless-express`, and other packages using the `"require"` condition in their `exports` field.

---

### Fix 2 — `templates/react-vite-starter/tsconfig.json.template`

Remove `"types": ["node"]` from `compilerOptions`

**Why:** With TypeScript 6.0 and `"moduleResolution": "Bundler"`, the explicit `"types": ["node"]` restriction prevents TypeScript from discovering type declarations for:
- `@apollo/client` (react-apollo extension)  
- `i18next`, `react-i18next` (react-i18n extension)
- `million/react` (react-million extension)
- `react-redux`, `@reduxjs/toolkit`, `redux-persist` (react-redux-thunk extension)

TypeScript 6 bundler mode requires types to be declared via package `exports["types"]`. When `"types": ["node"]` is set, TypeScript skips the default `@types/` scan, causing all packages using root-level `types` field to be invisible.

The `"types": ["node"]` restriction belongs only in `tsconfig.node.json` (Vite's Node.js config for `vite.config.ts`), not in the browser app's main tsconfig.

---

Closes #205, Closes #206