### PR TITLE
fix(tsconfig): module:Preserve for react-vite, moduleResolution:bundler for nestjs

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -15,7 +15,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "types": ["jest", "node"],
-    "moduleResolution": "node16",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"
   },

--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -9,7 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
+    "module": "Preserve",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
Two TypeScript 6.0 compatibility tweaks following iterative diagnosis in CI. **react-vite**: change module:ESNext → module:Preserve (TypeScript 5.4+ recommended for bundler scenarios). **nestjs**: change moduleResolution:node16 → moduleResolution:bundler (node16 strict require-condition lookup misses drizzle-kit; bundler finds it via default condition scan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated starter template TypeScript settings for improved compatibility with modern tooling.
  * Adjusted default module handling in the React Vite starter and module resolution in the NestJS starter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->