### PR TITLE
fix(nestjs): revert module to commonjs for valid bundler moduleResolution

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "node16",
+    "module": "commonjs",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
TypeScript 6 TS5095: bundler can only be used with module:preserve/commonjs/es2015+. The previous state (module:node16 + moduleResolution:bundler) is invalid. Revert module to commonjs — this is the one valid combination for NestJS that also supports bundler resolution for modern packages like drizzle-kit.