### PR TITLE
fix(react-vite): restore types:[node] accidentally removed in #213

### DIFF
--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -14,6 +14,7 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["node"],
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }


### PR DESCRIPTION
PR #213 removed types:[node] to try to fix @apollo/client resolution. This broke require() and process.env (TS2591) because @types/node is not in the template devDependencies. Restore the array — the apollo/i18n issues are unrelated and tracked in #205/#206.