### PR TITLE
fix(apollo): downgrade to @apollo/client@^3.11.8 for TypeScript 6 compatibility

### DIFF
--- a/extensions/react-apollo/package.json
+++ b/extensions/react-apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-apollo-extension",
   "dependencies": {
-    "@apollo/client": "^4.2.6",
-    "graphql": "^17.0.2"
+    "@apollo/client": "^3.11.8",
+    "graphql": "^16.9.0"
   }
 }

--- a/extensions/react-apollo/src/lib/apollo-client.ts
+++ b/extensions/react-apollo/src/lib/apollo-client.ts
@@ -1,4 +1,5 @@
-import { ApolloClient, InMemoryCache, HttpLink, from, onError } from '@apollo/client';
+import { ApolloClient, InMemoryCache, HttpLink, from } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 
 const httpLink = new HttpLink({
   uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT || '/api/graphql',


### PR DESCRIPTION
Closes #217. Apollo Client v4 (bumped by Dependabot PR #188) is incompatible with TypeScript 6.0 moduleResolution:Bundler. Pin to v3.11.8 + graphql@^16.9.0. Reverts the onError import back to @apollo/client/link/error (v3 API).