### PR TITLE
fix(i18n): downgrade i18next ecosystem to v23.x for TypeScript 6 compatibility

### DIFF
--- a/extensions/react-i18n/package.json
+++ b/extensions/react-i18n/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "i18next": "^26.3.4",
-    "i18next-browser-languagedetector": "^8.2.1",
-    "i18next-http-backend": "^4.0.0",
-    "react-i18next": "^17.0.8"
+    "i18next": "^23.11.5",
+    "i18next-browser-languagedetector": "^7.2.2",
+    "i18next-http-backend": "^2.6.1",
+    "react-i18next": "^14.1.3"
   }
 }


### PR DESCRIPTION
Closes #217. i18next@26.x, i18next-browser-languagedetector@8.x, i18next-http-backend@4.x, react-i18next@17.x (all bumped by Dependabot PR #188) incompatible with TypeScript 6.0 bundler. Pin to last stable versions (v23.x/v7.x/v2.x/v14.x).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internationalization package dependencies to newer versions.
  * Improves compatibility and access to updates from the localization ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->