### PR TITLE
fix(nestjs): module:node16 + moduleResolution:node16 + exclude drizzle.config.ts

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -14,8 +14,11 @@
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,
-    "types": ["jest", "node"],
-    "moduleResolution": "bundler",
+    "types": [
+      "jest",
+      "node"
+    ],
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"
   },
@@ -25,6 +28,7 @@
     "*coverage",
     "logs",
     "scripts",
-    "./tools/**/*"
+    "./tools/**/*",
+    "drizzle.config.ts"
   ]
 }


### PR DESCRIPTION
Closes #218. node16/node16 uses require condition → drizzle-orm .d.cts files resolve correctly. drizzle.config.ts excluded (CLI config not NestJS app code — drizzle-kit ESM-only types not compatible with node16 CJS).