### PR TITLE
fix(react-vite): remove types restriction and revert to module:esnext

### DIFF
--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -9,12 +9,11 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "Preserve",
+    "module": "esnext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node"],
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }


### PR DESCRIPTION
Root cause: `"types": ["node"]` blocked auto-discovery of `@types/react` which packages like @apollo/client and react-i18next need globally. @types/node is already in devDependencies — the restriction was unnecessary. Also reverts module:Preserve → module:esnext (matching nextjs-starter which passes with react-apollo). Closes #217.