### PR TITLE
fix(nestjs): remove types restriction to allow @types package auto-discovery

### DIFF
--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -14,10 +14,6 @@
     "skipLibCheck": true,
     "allowJs": false,
     "esModuleInterop": true,
-    "types": [
-      "jest",
-      "node"
-    ],
     "moduleResolution": "node16",
     "resolveJsonModule": true,
     "ignoreDeprecations": "6.0"


### PR DESCRIPTION
The "types": ["jest", "node"] restriction blocked TypeScript 6 from finding @types/pg (from nestjs-drizzle extensions) and @types/aws-lambda (from nestjs-serverless). Both @types/jest and @types/node are in devDependencies and auto-discovered. Fixes TS2307 for drizzle-orm subpaths, pg, and aws-lambda.