### PR TITLE
fix(react-million): add missing slicer.scss and cracked.css files

### DIFF
--- a/extensions/react-million/[src]/components/Animation/cracked.css
+++ b/extensions/react-million/[src]/components/Animation/cracked.css
@@ -1,0 +1,10 @@
+.bg-text {
+  position: relative;
+  overflow: hidden;
+}
+
+.slicer-gradient {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}

--- a/extensions/react-million/[src]/components/Animation/slicer.scss
+++ b/extensions/react-million/[src]/components/Animation/slicer.scss
@@ -1,0 +1,7 @@
+.text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
Cracked.tsx imported ./slicer.scss and ./cracked.css which were not included in the extension, causing ESLint import/no-unresolved errors that failed lint:fix in every combination including react-million.