### PR TITLE
fix(nestjs): restore types:[jest,node] and pin drizzle-orm to 0.45.1

### DIFF
--- a/extensions/nestjs-drizzle-postgres/package.json
+++ b/extensions/nestjs-drizzle-postgres/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.744.0",
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "0.45.1",
     "pg": "^8.13.3"
   },
   "devDependencies": {

--- a/extensions/nestjs-drizzle-sqlite/package.json
+++ b/extensions/nestjs-drizzle-sqlite/package.json
@@ -6,7 +6,7 @@
     "drizzle:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "0.45.1",
     "better-sqlite3": "^12.11.1"
   },
   "devDependencies": {

--- a/templates/nestjs-starter/tsconfig.json
+++ b/templates/nestjs-starter/tsconfig.json
@@ -16,7 +16,11 @@
     "esModuleInterop": true,
     "moduleResolution": "node16",
     "resolveJsonModule": true,
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "6.0",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
1. Restore types:[jest,node] — required for Jest globals (describe/it/expect) in module:node16 mode. 2. Pin drizzle-orm to exact 0.45.1 which has confirmed .d.cts files for node16 CJS require-condition resolution.