### PR TITLE
fix(react-vite): add baseUrl:. and restore types:[node] to tsconfig

### DIFF
--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -14,6 +14,8 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
       "<%= projectImportPath%>*": ["./<%= srcDir%>/*"]
     }


### PR DESCRIPTION
1. baseUrl:. — TypeScript 6 bundler mode needs explicit baseUrl when paths are used; without it module resolution root may be incorrect. 2. types:[node] — restored to make process.env/require/module globals available in extension source files.