### PR TITLE
fix(react-vite): suppress baseUrl deprecation with ignoreDeprecations:6.0

### DIFF
--- a/templates/react-vite-starter/tsconfig.json.template
+++ b/templates/react-vite-starter/tsconfig.json.template
@@ -12,6 +12,7 @@
     "module": "esnext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
+    "ignoreDeprecations": "6.0",
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": ".",


### PR DESCRIPTION
baseUrl is deprecated in TypeScript 6 (TS5101). Add ignoreDeprecations:6.0 to suppress the deprecation error while keeping baseUrl:. for correct module resolution root.