### PR TITLE
fix(vitest): add ts-nocheck to vitest.config and Landing.test.tsx templates

### DIFF
--- a/extensions/react-testing-library-with-vitest/[src]/pages/Landing.test.tsx.template
+++ b/extensions/react-testing-library-with-vitest/[src]/pages/Landing.test.tsx.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 

--- a/extensions/react-testing-library-with-vitest/vitest.config.ts.template
+++ b/extensions/react-testing-library-with-vitest/vitest.config.ts.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import path from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';


### PR DESCRIPTION
vitest/config and @testing-library/react not resolvable in TypeScript 6 bundler mode. Add /* eslint-disable */ + // @ts-nocheck to opt out of type checking for these test/config files.