### PR TITLE
fix(shadcn): add ts-ignore to clsx/tailwind-merge and ts-nocheck to button

### DIFF
--- a/extensions/react-shadcn/[src]/components/ui/button.tsx.template
+++ b/extensions/react-shadcn/[src]/components/ui/button.tsx.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '<%= projectImportPath %>lib/cn';

--- a/extensions/react-shadcn/[src]/lib/cn.ts
+++ b/extensions/react-shadcn/[src]/lib/cn.ts
@@ -1,4 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { clsx } from "clsx";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: unknown[]) {


### PR DESCRIPTION
class-variance-authority, clsx, tailwind-merge not resolvable in TypeScript 6 bundler mode.