### PR TITLE
fix(storybook): downgrade all storybook packages to ^8.6.18

### DIFF
--- a/extensions/storybook/package.json
+++ b/extensions/storybook/package.json
@@ -3,12 +3,12 @@
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.18",
     "@storybook/addon-interactions": "^8.6.18",
-    "@storybook/addon-links": "^10.4.6",
+    "@storybook/addon-links": "^8.6.18",
     "@storybook/blocks": "^8.6.18",
-    "@storybook/nextjs": "^10.4.6",
-    "@storybook/react": "^10.4.6",
+    "@storybook/nextjs": "^8.6.18",
+    "@storybook/react": "^8.6.18",
     "@storybook/test": "^8.6.18",
-    "storybook": "^10.4.6"
+    "storybook": "^8.6.18"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
Dependabot PR #188 bumped some packages to v10 causing mixed v8/v10 state → build failures. Pin ALL to ^8.6.18 per constraint in CLAUDE.md (do not upgrade to v10 without resolving issue #161).