### PR TITLE
fix(redux-thunk): add ts-ignore to unresolvable redux imports

### DIFF
--- a/extensions/react-redux-thunk/[src]/app-providers.tsx.append.template
+++ b/extensions/react-redux-thunk/[src]/app-providers.tsx.append.template
@@ -1,4 +1,6 @@
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { Provider as ReduxThunkProvider } from 'react-redux';
 import { store as reduxThunkStore } from '<%= projectImportPath %>store';
 

--- a/extensions/react-redux-thunk/[src]/reducers/index.ts
+++ b/extensions/react-redux-thunk/[src]/reducers/index.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { combineReducers } from '@reduxjs/toolkit';
 
 const rootReducer = combineReducers({

--- a/extensions/react-redux-thunk/[src]/store.ts.template
+++ b/extensions/react-redux-thunk/[src]/store.ts.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import { configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
 import { persistStore, persistReducer } from 'redux-persist';

--- a/extensions/react-redux-thunk/[src]/types/store.ts.template
+++ b/extensions/react-redux-thunk/[src]/types/store.ts.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import type { store } from '<%= projectImportPath %>store';
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
@reduxjs/toolkit, react-redux, redux-logger, redux-persist not resolvable in TypeScript 6 bundler mode.