### PR TITLE
fix(vite): add rolldownOptions.external for @storybook/* to prevent Rolldown build failure

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -62,5 +62,9 @@ export default defineConfig({
   },
   build: {
     cssMinify: false,
+    rolldownOptions: {
+      // Prevent bundling of Storybook packages in production — they are dev-only
+      external: [/^@storybook\//],
+    },
   },
 });


### PR DESCRIPTION
Vite 8 Rolldown raises an error when dev-only @storybook/* packages are detected in the browser bundle. Add external pattern to suppress the error.