### PR TITLE
fix(shadcn): downgrade tailwindcss from v4 to ^3.4.0

### DIFF
--- a/extensions/react-shadcn/package.json
+++ b/extensions/react-shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^3.4.0",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
Dependabot bumped tailwindcss to v4 but the PostCSS config uses v3 API. v4 requires @tailwindcss/postcss instead of tailwindcss plugin. Downgrade to ^3.4.0 to match existing config format.