### PR TITLE
fix: downgrade tailwindcss v4 to ^3.4.0 in react-tailwindcss and nextjs-tailwindcss

### DIFF
--- a/extensions/nextjs-tailwindcss/package.json
+++ b/extensions/nextjs-tailwindcss/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs-tailwindcss-extension",
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.18",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.23",

--- a/extensions/react-tailwindcss/package.json
+++ b/extensions/react-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^3.4.0",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20"
   }


### PR DESCRIPTION
Dependabot bumped tailwindcss to v4 but these extensions use v3-style postcss config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for the Next.js and React Tailwind CSS extensions by aligning them with Tailwind CSS 3.4.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->