### PR TITLE
fix(vite): add recoil-devtools/* to rolldownOptions.external

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -63,8 +63,8 @@ export default defineConfig({
   build: {
     cssMinify: false,
     rolldownOptions: {
-      // Prevent bundling of Storybook packages in production — they are dev-only
-      external: [/^@storybook\//],
+      // Prevent bundling of packages that are dev-only or CJS-only tools
+      external: [/^@storybook\//, /^recoil-devtools/],
     },
   },
 });


### PR DESCRIPTION
recoil-devtools-* are CJS-only dev tools that Rolldown flags as unintended browser bundling. Add to external list alongside @storybook/*.