### PR TITLE
fix(vite): add workbox-* to rolldownOptions.external

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -63,8 +63,8 @@ export default defineConfig({
   build: {
     cssMinify: false,
     rolldownOptions: {
-      // Prevent bundling of packages that are dev-only or CJS-only tools
-      external: [/^@storybook\//, /^recoil-devtools/],
+      // Prevent bundling of packages that are dev-only, CJS-only, or SW-specific
+      external: [/^@storybook\//, /^recoil-devtools/, /^workbox-/],
     },
   },
 });


### PR DESCRIPTION
vite-plugin-pwa's service worker uses workbox CJS code that Rolldown flags as unintended browser bundling. Add to external list.