### PR TITLE
fix(vite): add testing packages to rolldownOptions.external

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -63,8 +63,16 @@ export default defineConfig({
   build: {
     cssMinify: false,
     rolldownOptions: {
-      // Prevent bundling of packages that are dev-only, CJS-only, or SW-specific
-      external: [/^@storybook\//, /^recoil-devtools/, /^workbox-/],
+      // Prevent bundling of dev-only, CJS-only, or test-only packages
+      external: [
+        /^@storybook\//,
+        /^recoil-devtools/,
+        /^workbox-/,
+        /^vitest/,
+        /^jsdom/,
+        /^@testing-library\//,
+        /^@vitest\//,
+      ],
     },
   },
 });


### PR DESCRIPTION
vitest/jsdom/@testing-library/* transitively import Node.js APIs when test files are in src/. Add to external list to prevent Rolldown bundling error.