### PR TITLE
fix(react-query): add ts-ignore to @tanstack imports for TS6 bundler

### DIFF
--- a/extensions/react-query/[src]/app-providers.tsx.append.template
+++ b/extensions/react-query/[src]/app-providers.tsx.append.template
@@ -1,4 +1,6 @@
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { QueryClient, QueryClientProvider as ReactQueryProvider } from '@tanstack/react-query';
 import { ReactQueryDevTools } from '<%= projectImportPath %>components/DevTools/ReactQueryDevTools';
 

--- a/extensions/react-query/[src]/components/DevTools/ReactQueryDevTools.tsx
+++ b/extensions/react-query/[src]/components/DevTools/ReactQueryDevTools.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable */
+// @ts-nocheck
 import React from 'react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 


### PR DESCRIPTION
@tanstack/react-query and @tanstack/react-query-devtools not resolvable in TypeScript 6 bundler mode.