### PR TITLE
fix(vite): add @playwright/* to rolldownOptions.external

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -72,6 +72,8 @@ export default defineConfig({
         /^jsdom/,
         /^@testing-library\//,
         /^@vitest\//,
+        /^@playwright\//,
+        /^playwright$/,
       ],
     },
   },


### PR DESCRIPTION
playwright.config.ts imports @playwright/test which uses Node.js APIs → Rolldown flags as unintended bundling.