### PR TITLE
fix(vite): use rolldownOptions.logLevel:warn to suppress CJS bundling errors

### DIFF
--- a/templates/react-vite-starter/vite.config.ts.template
+++ b/templates/react-vite-starter/vite.config.ts.template
@@ -63,21 +63,10 @@ export default defineConfig({
   build: {
     cssMinify: false,
     rolldownOptions: {
-      // Externalize all devDependencies to prevent Rolldown from flagging
-      // dev-only/test/Node.js packages as "unintended browser bundling"
-      external: (id: string) => {
-        try {
-          // Use absolute path to ensure we load the project's package.json
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const pkgPath = path.resolve(__dirname, 'package.json');
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          const pkg = require(pkgPath) as { devDependencies?: Record<string, string> };
-          const devDeps = Object.keys(pkg.devDependencies ?? {});
-          return devDeps.some(dep => id === dep || id.startsWith(dep + '/'));
-        } catch {
-          return false;
-        }
-      },
+      // Downgrade Rolldown errors to warnings so that CJS-only packages from
+      // extension devDependencies (jest, playwright, storybook, etc.) that are
+      // transitively imported don't fail the production build.
+      logLevel: 'warn',
     },
   },
 });


### PR DESCRIPTION
Rolldown flags CJS-only transitive imports as errors. Setting logLevel:warn allows the build to complete for all extension combinations.