### PR TITLE
fix(postcss): use explicit require() in postcss.config for reliable resolution

### DIFF
--- a/extensions/react-shadcn/postcss.config.js.template
+++ b/extensions/react-shadcn/postcss.config.js.template
@@ -1,7 +1,8 @@
 /** PostCSS Config (templated, shadcn) */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ],
 };

--- a/extensions/react-tailwindcss/postcss.config.js.template
+++ b/extensions/react-tailwindcss/postcss.config.js.template
@@ -1,7 +1,8 @@
 /** PostCSS Config */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ],
 };


### PR DESCRIPTION
Change from object-form { tailwindcss: {} } to explicit require('tailwindcss') in both react-tailwindcss and react-shadcn postcss configs.