### PR TITLE
fix(postcss): use require.resolve with paths:[cwd] for tailwindcss discovery

### DIFF
--- a/extensions/react-shadcn/postcss.config.js.template
+++ b/extensions/react-shadcn/postcss.config.js.template
@@ -1,8 +1,11 @@
-/** PostCSS Config (templated, shadcn) */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolve } = require('path');
+const cwd = process.cwd();
 module.exports = {
   plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require(resolve(require.resolve('tailwindcss', { paths: [cwd] }))),
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require(resolve(require.resolve('autoprefixer', { paths: [cwd] }))),
   ],
 };

--- a/extensions/react-tailwindcss/postcss.config.js.template
+++ b/extensions/react-tailwindcss/postcss.config.js.template
@@ -1,8 +1,11 @@
-/** PostCSS Config */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const { resolve } = require('path');
+const cwd = process.cwd();
 module.exports = {
   plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require(resolve(require.resolve('tailwindcss', { paths: [cwd] }))),
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require(resolve(require.resolve('autoprefixer', { paths: [cwd] }))),
   ],
 };


### PR DESCRIPTION
When legacy-peer-deps=true causes tailwindcss to be nested, require('tailwindcss') fails. Use require.resolve with paths:[process.cwd()] to find it from the project root.