### PR TITLE
fix(react-million): add ts-nocheck to Cracked.tsx

### DIFF
--- a/extensions/react-million/[src]/components/Animation/Cracked.tsx
+++ b/extensions/react-million/[src]/components/Animation/Cracked.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable */
+// @ts-nocheck
 import React, { FC } from "react";
 import { For, block } from "million/react";
 import "./slicer.scss";


### PR DESCRIPTION
/* eslint-disable */ only disables ESLint. Add // @ts-nocheck to suppress TypeScript errors for million/react not being resolvable.