### PR TITLE
fix(react-vite): add less to base template devDependencies

### DIFF
--- a/templates/react-vite-starter/package/devDependencies.js
+++ b/templates/react-vite-starter/package/devDependencies.js
@@ -19,4 +19,5 @@ module.exports = {
   vite: '^8.1.3',
   'vite-plugin-eslint': '^1.8.1',
   'vite-plugin-pwa': '^1.3.0',
+  'less': '^4.2.0',
 };


### PR DESCRIPTION
Vite.config already configures less preprocessor. Adding less to template devDeps ensures it's available at root even when legacy-peer-deps causes nesting.