### PR TITLE
fix(react-vite): add npm overrides to ensure tailwindcss is hoisted to root

### DIFF
--- a/templates/react-vite-starter/package/index.js
+++ b/templates/react-vite-starter/package/index.js
@@ -28,5 +28,11 @@ module.exports = function resolvePackage(setup, { appName, runCommand }) {
     },
   };
 
-  return { ...packageJson, dependencies, devDependencies };
+  // npm overrides ensure CSS-related packages from extensions are always
+  // hoisted to root even when legacy-peer-deps=true is in use
+  const overrides = {
+    tailwindcss: '^3.4.0',
+  };
+
+  return { ...packageJson, dependencies, devDependencies, overrides };
 };


### PR DESCRIPTION
legacy-peer-deps=true from ionic/hookstate extensions causes tailwindcss to be nested. npm overrides force it to root.