### PR TITLE
fix(react-vite): add tailwindcss/postcss/autoprefixer to base template devDeps

### DIFF
--- a/templates/react-vite-starter/package/devDependencies.js
+++ b/templates/react-vite-starter/package/devDependencies.js
@@ -20,4 +20,7 @@ module.exports = {
   'vite-plugin-eslint': '^1.8.1',
   'vite-plugin-pwa': '^1.3.0',
   'less': '^4.2.0',
+  'tailwindcss': '^3.4.0',
+  'postcss': '^8.4.47',
+  'autoprefixer': '^10.4.20',
 };


### PR DESCRIPTION
Guarantees tailwindcss is at root even when legacy-peer-deps causes nesting in combined extension scenarios.