### PR TITLE
fix(wdio-starter): fix type errors after WDIO v9 upgrade

### DIFF
--- a/templates/wdio-starter/bin/suite-spec-paths.ts
+++ b/templates/wdio-starter/bin/suite-spec-paths.ts
@@ -25,7 +25,16 @@ if (!suite) {
   process.exit(0);
 }
 
-const suiteChunk = getSuiteSpecFiles(suite);
+const specs: string[] = [];
+for (const entry of suite) {
+  if (Array.isArray(entry)) {
+    specs.push(...entry);
+  } else {
+    specs.push(entry);
+  }
+}
+
+const suiteChunk = getSuiteSpecFiles(specs);
 
 for (const spec of suiteChunk) {
   console.log(spec);

--- a/templates/wdio-starter/config/env.ts
+++ b/templates/wdio-starter/config/env.ts
@@ -157,7 +157,7 @@ export const getCapabilityMaxInstances = (capabilityName: DisaredCapabilityName)
  *
  * @returns Partial<WebDriver.DesiredCapabilities> - options override for capabilities
  */
-export const getCapabilityOptionsOverride = (): Partial<WebDriver.DesiredCapabilities> =>
+export const getCapabilityOptionsOverride = (): Partial<WebdriverIO.Capabilities> =>
   getExecutionMode() === 'local'
     ? {}
     : {

--- a/templates/wdio-starter/config/wdio.capabilities.conf.ts
+++ b/templates/wdio-starter/config/wdio.capabilities.conf.ts
@@ -11,24 +11,24 @@ const headless = isHeadlessMode();
 
 const maxInstances = getCapabilitiesMaxInstances();
 
-const capabilitiesMap: Record<DisaredCapabilityName, () => WebDriver.DesiredCapabilities> = {
+const capabilitiesMap: Record<DisaredCapabilityName, () => WebdriverIO.Capabilities> = {
   firefox: () => ({
     maxInstances: getCapabilityMaxInstances('firefox'),
-    browserName: 'firefox',
+    browserName: 'firefox' as const,
     'moz:firefoxOptions': {
       args: headless ? ['-headless'] : [],
     },
   }),
   chrome: () => ({
     maxInstances: getCapabilityMaxInstances('chrome'),
-    browserName: 'chrome',
+    browserName: 'chrome' as const,
     'goog:chromeOptions': {
       args: headless ? ['--headless', '--window-size=1920,1080'] : ['--start-maximized'],
     },
   }),
   mobile_chrome: () => ({
     maxInstances: getCapabilityMaxInstances('mobile_chrome'),
-    browserName: 'chrome',
+    browserName: 'chrome' as const,
     'goog:chromeOptions': {
       args: headless ? ['--headless', '--window-size=1920,1080'] : ['--start-maximized'],
       mobileEmulation: { deviceName: 'Pixel 2 XL' },
@@ -36,14 +36,14 @@ const capabilitiesMap: Record<DisaredCapabilityName, () => WebDriver.DesiredCapa
   }),
   safari: () => ({
     maxInstances: getCapabilityMaxInstances('safari'),
-    browserName: 'safari',
+    browserName: 'safari' as const,
     'safari.options': {
       args: headless ? ['--headless', '--window-size=1920,1080'] : ['--window-size=1920,1080'],
     },
   }),
 };
 
-const capabilities: WebDriver.DesiredCapabilities[] = getDesiredCapabilitiesNames().map((name) => ({
+const capabilities: WebdriverIO.Capabilities[] = getDesiredCapabilitiesNames().map((name) => ({
   ...capabilitiesMap[name](),
   ...getCapabilityOptionsOverride(),
   acceptInsecureCerts: true,

--- a/templates/wdio-starter/config/wdio.local.conf.ts
+++ b/templates/wdio-starter/config/wdio.local.conf.ts
@@ -1,4 +1,4 @@
-const driverOpts = {
+const driverOpts: Record<string, any> = {
   drivers: {
     chromiumedge: {
       version: 'latest',

--- a/templates/wdio-starter/test/specs/example.e2e.ts
+++ b/templates/wdio-starter/test/specs/example.e2e.ts
@@ -10,6 +10,6 @@ describe('My Login application', () => {
 
     await LoginPage.login('tomsmith', 'SuperSecretPassword!');
     await expect(SecurePage.flashAlert).toBeExisting();
-    await expect(SecurePage.flashAlert).toHaveTextContaining('You logged into a secure area!');
+    await expect(SecurePage.flashAlert).toHaveText('You logged into a secure area!', { containing: true });
   });
 });

--- a/templates/wdio-starter/types/selenium-standalone.d.ts
+++ b/templates/wdio-starter/types/selenium-standalone.d.ts
@@ -1,0 +1,37 @@
+declare module 'selenium-standalone' {
+  interface DriverOptions {
+    version?: string;
+    arch?: string;
+    baseURL?: string;
+    onlyDriverArgs?: string[];
+  }
+
+  interface InstallOptions {
+    version?: string;
+    baseURL?: string;
+    drivers?: Record<string, DriverOptions>;
+    ignoreExtraDrivers?: boolean;
+    basePath?: string;
+    logger?: (message: string) => void;
+    requestOpts?: Record<string, any>;
+    progressCb?: (totalLength: number, progressLength: number, chunkLength: number) => void;
+    onlyDriver?: string;
+  }
+
+  interface StartOptions {
+    version?: string;
+    baseURL?: string;
+    drivers?: Record<string, DriverOptions>;
+    ignoreExtraDrivers?: boolean;
+    basePath?: string;
+    spawnOptions?: Record<string, any>;
+    javaArgs?: string[];
+    seleniumArgs?: string[];
+    javaPath?: string;
+    requestOpts?: Record<string, any>;
+    onlyDriver?: string;
+  }
+
+  export function install(opts?: InstallOptions): Promise<void>;
+  export function start(opts?: StartOptions): Promise<import('child_process').ChildProcess>;
+}


### PR DESCRIPTION
## Summary

Fix type errors found by CI in the WDIO v9 upgrade (PR #286):

- `WebDriver` → `WebdriverIO` namespace (v9 global type change)
- Add `types/selenium-standalone.d.ts` declaration file (no types published)
- Fix suite spec type handling for WDIO v9 suites API (`(string|string[])[]`)
- Update `toHaveTextContaining` → `toHaveText` with `{ containing: true }`