### PR TITLE
docs: encode M1 template maturity checklist (#291)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Use [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:
 - [ ] `slug` is globally unique across templates and extensions
 - [ ] All required fields present: `name`, `slug`, `description`, `url`, `type`, `category`, `labels`
 - [ ] Extension `type` is an array if it supports multiple template types
-- [ ] New/updated templates meet [M1 maturity](./docs/MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3) (or link an uplift issue)
+- [ ] **New** templates meet [M1 maturity](./docs/MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3). Updates to existing thin starters must link an uplift issue until M1 is met
 - [ ] Tested locally — see [docs/TESTING.md](./docs/TESTING.md)
 
 ## Questions?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,12 @@ For a full explanation of how templates, extensions, and the file system work, r
 ## Adding a template
 
 1. Create `templates/<your-slug>/`
-2. Set up `package/index.js`, `package/dependencies.js`, `package/devDependencies.js`
+2. Set up `package/index.js`, `package/dependencies.js`, `package/devDependencies.js` (preferred) — or a deliberate static `package.json`
 3. Add project files with the appropriate suffixes
-4. Register it in `templates.json` under `"templates"` (same fields as extension, plus optional `customOptions`)
+4. Meet the **M1 maturity checklist** in [docs/MAINTENANCE_TEMPLATES.md §11](./docs/MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3) (docs suite, real lint, honest scripts, landing integrity)
+5. Register it in `templates.json` under `"templates"` (same fields as extension; put interactive prompts in `cna.config.json`, not the registry)
+
+For a full explanation of how templates, extensions, and the file system work, read [docs/AUTHORING.md](./docs/AUTHORING.md).
 
 ## Commit messages
 
@@ -36,11 +39,12 @@ Use [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:
 
 ## PR checklist
 
-- [ ] Directory name matches the `slug` in `templates.json`
+- [ ] Directory name matches the `slug` in `templates.json` (or the `url` path if they intentionally differ — see [MAINTENANCE_TEMPLATES.md](./docs/MAINTENANCE_TEMPLATES.md#52-directory-naming-caveat))
 - [ ] `url` points to the correct path on the `main` branch
 - [ ] `slug` is globally unique across templates and extensions
 - [ ] All required fields present: `name`, `slug`, `description`, `url`, `type`, `category`, `labels`
 - [ ] Extension `type` is an array if it supports multiple template types
+- [ ] New/updated templates meet [M1 maturity](./docs/MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3) (or link an uplift issue)
 - [ ] Tested locally — see [docs/TESTING.md](./docs/TESTING.md)
 
 ## Questions?

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -106,7 +106,7 @@ Before merging a new or heavily revised starter, meet the **M1 mature scaffold**
 
 In short:
 
-- Prefer `package/index.js` over a static `package.json` unless you are intentionally shipping a lockfile showcase.
+- Prefer `package/index.js` over a static `package.json` unless you intentionally ship a static package (e.g. Next.js-style showcases with a lockfile).
 - Ship a real `docs/` suite; **never** link landings or READMEs to docs that do not exist.
 - `lint` / `test` scripts must do real work (or be omitted) — no `echo` stubs and no fake README scripts.
 - Use `react-vite-starter` / `nextjs-starter` as the reference; do **not** treat `nextjs-saas-ai-starter` as the default scope.

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -99,3 +99,14 @@ Define them in `cna.config.json` at the root of the template directory:
 
 > `cna.config.json` is co-located with the template so it works with both slug resolution and `file://` local URLs.
 > Do **not** put `customOptions` in `templates.json` — it is no longer read from there.
+
+## Template maturity
+
+Before merging a new or heavily revised starter, meet the **M1 mature scaffold** bar documented in [MAINTENANCE_TEMPLATES.md §11](./MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3).
+
+In short:
+
+- Prefer `package/index.js` over a static `package.json` unless you are intentionally shipping a lockfile showcase.
+- Ship a real `docs/` suite; **never** link landings or READMEs to docs that do not exist.
+- `lint` / `test` scripts must do real work (or be omitted) — no `echo` stubs and no fake README scripts.
+- Use `react-vite-starter` / `nextjs-starter` as the reference; do **not** treat `nextjs-saas-ai-starter` as the default scope.

--- a/docs/DEFAULT_LANDING_GUIDE.md
+++ b/docs/DEFAULT_LANDING_GUIDE.md
@@ -21,7 +21,7 @@ The landing pages follow the CNA design system defined in [`DEFAULT_LANDING_DESI
 | `shared/assets/logo-mark-dark.svg` | Dark-background variant of the mark |
 | `shared/assets/favicon.svg` | Favicon source |
 
-When the identity changes, update the master files first, then copy them into each affected template.
+When the identity changes, update the master files first, then copy them into each affected template (or run the shared-asset sync script when available). **Landing documentation links must resolve** to files that exist in the template (see [MAINTENANCE_TEMPLATES.md §11](./MAINTENANCE_TEMPLATES.md#11-template-maturity-m1--m2--m3) hard rule #1).
 
 ---
 

--- a/docs/MAINTENANCE_TEMPLATES.md
+++ b/docs/MAINTENANCE_TEMPLATES.md
@@ -288,7 +288,7 @@ If any step fails, fix the template or extension, then regenerate from scratch. 
 - [ ] `incompatibleWith` is defined for mutually exclusive extensions.
 - [ ] `.npmrc` is added if peer-dependency conflicts exist.
 - [ ] `.template` files use available EJS variables.
-- [ ] **M1 maturity** criteria in [§11](#11-template-maturity-m1--m2--m3) are met (or gaps are tracked in an issue).
+- [ ] **M1 maturity** criteria in [§11](#11-template-maturity-m1--m2--m3) are met for **new** templates. Existing thin starters may merge only with an uplift issue linked until they reach M1.
 - [ ] Local validation passes.
 - [ ] Full matrix worst case (all compatible extensions) is tested for risky changes.
 
@@ -298,8 +298,8 @@ If any step fails, fix the template or extension, then regenerate from scratch. 
 
 New templates must not ship as thin `create-<framework>` shells. Use this bar so every starter adds **differential CNA value**.
 
-**Gold references (M1/M2):** `templates/react-vite-starter`, `templates/nextjs-starter`  
-**Flagship ceiling (M3 — not required for new starters):** `templates/nextjs-saas-ai-starter`
+**Gold references (M1/M2):** [`templates/react-vite-starter`](../templates/react-vite-starter/), [`templates/nextjs-starter`](../templates/nextjs-starter/)  
+**Flagship ceiling (M3 — not required for new starters):** [`templates/nextjs-saas-ai-starter`](../templates/nextjs-saas-ai-starter/)
 
 ### 11.1 Maturity tiers
 

--- a/docs/MAINTENANCE_TEMPLATES.md
+++ b/docs/MAINTENANCE_TEMPLATES.md
@@ -156,13 +156,14 @@ Remove extensions one at a time until the project passes. Then fix the last remo
 ### 5.1 Adding a template
 
 1. Create `templates/<directory>/`.
-2. Add `package/index.js` (and optionally `dependencies.js`/`devDependencies.js`).
+2. Add `package/index.js` (and optionally `dependencies.js`/`devDependencies.js`), **or** an intentional static `package.json` (Next.js-style showcases). Prefer `package/index.js` for new starters.
 3. Add source files and `.template` files.
 4. Add `cna.config.json` with `customOptions` if interactive prompts are needed.
-5. Add an entry to `templates.json` under `templates`.
-6. Ensure the entry point matches the directory structure.
-7. Run local validation against the new template.
-8. Run the full matrix after merge.
+5. Meet the **M1 maturity bar** in [§11](#11-template-maturity-m1--m2--m3) before merge (docs, DX, honest scripts, landing integrity).
+6. Add an entry to `templates.json` under `templates`.
+7. Ensure the entry point matches the directory structure.
+8. Run local validation against the new template.
+9. Run the full matrix after merge.
 
 ### 5.2 Directory naming caveat
 
@@ -287,5 +288,84 @@ If any step fails, fix the template or extension, then regenerate from scratch. 
 - [ ] `incompatibleWith` is defined for mutually exclusive extensions.
 - [ ] `.npmrc` is added if peer-dependency conflicts exist.
 - [ ] `.template` files use available EJS variables.
+- [ ] **M1 maturity** criteria in [§11](#11-template-maturity-m1--m2--m3) are met (or gaps are tracked in an issue).
 - [ ] Local validation passes.
 - [ ] Full matrix worst case (all compatible extensions) is tested for risky changes.
+
+---
+
+## 11. Template maturity (M1 / M2 / M3)
+
+New templates must not ship as thin `create-<framework>` shells. Use this bar so every starter adds **differential CNA value**.
+
+**Gold references (M1/M2):** `templates/react-vite-starter`, `templates/nextjs-starter`  
+**Flagship ceiling (M3 — not required for new starters):** `templates/nextjs-saas-ai-starter`
+
+### 11.1 Maturity tiers
+
+| Tier | Intent | Examples |
+|---|---|---|
+| **M1 — Mature scaffold** | Opinionated layout, full docs, real DX tooling, honest README, CNA first-run UX | `react-vite-starter` |
+| **M2 — Full-stack / domain baseline** | M1 + sample feature, env validation, richer API/testing docs | `nextjs-starter` (+ Nest after polish) |
+| **M3 — Flagship product** | Multi-domain product (auth, DB, tenancy, CI baked in) | `nextjs-saas-ai-starter` only |
+
+### 11.2 M1 checklist (required for smoke-matrix starters)
+
+#### A — CNA plumbing
+
+- [ ] Registry entry complete (`name`, `slug`, `description`, `url`, `type`, `category`, `labels`).
+- [ ] `package/index.js` (+ optional dep helpers) **or** intentional static `package.json`.
+- [ ] `.template` / `.append` / `[bracket]/` used correctly; EJS vars only from the documented set.
+- [ ] Local validation (§9) passes: install → format → lint → type-check → build.
+
+#### B — Docs suite
+
+- [ ] `docs/README.md` indexes the suite.
+- [ ] Core docs present (adapt names for backend/test harnesses): structure, configuration, and domain guides as applicable.
+- [ ] `README.md.template`, `CONTRIBUTING.md.template`, `AGENTS.md` or `AGENTS.md.template`.
+- [ ] **Landing / README CTAs must not link to missing files** (including after stripping `.template`). See [DEFAULT_LANDING_GUIDE.md](./DEFAULT_LANDING_GUIDE.md).
+
+#### C — Architecture
+
+- [ ] Opinionated layout (e.g. `features/`, Nest modules, RR7 routes, Astro `src/pages` + layouts).
+- [ ] Feature / module scaffold (`_feature-template_`, `_module-template_`, or documented equivalent).
+
+#### D — DX tooling
+
+- [ ] TypeScript strict + path alias when relevant.
+- [ ] **Real** ESLint flat config (`lint` must not be an `echo` stub).
+- [ ] Prettier + `.editorconfig` + `.node-version`.
+- [ ] Core scripts: `dev` (or harness equivalent), `build`, `lint`, `lint:fix`, `type-check`, `format`.
+
+#### E — First-run UX
+
+- [ ] UI templates: CNA default landing per [DEFAULT_LANDING_GUIDE.md](./DEFAULT_LANDING_GUIDE.md).
+- [ ] API / non-UI templates: branded README + health (or equivalent) endpoint.
+
+#### F — Env
+
+- [ ] `.env.example` with documented variables (even if empty of secrets).
+- [ ] Server templates should validate env (Zod, Nest Config, t3-env, etc.) at M2; M1 at least documents vars.
+
+#### G — Honesty
+
+- [ ] Every script listed in README exists in `package.json` / `package/index.js`.
+- [ ] Tests either ship in-template **or** are clearly extension-only — never advertise fake `test` scripts.
+
+#### H — Extension seams
+
+- [ ] Documented hooks for the template `type` (providers, middleware handlers, global CSS, etc.).
+
+### 11.3 Hard rules (CI / review blockers)
+
+1. **No dead doc links** from landing pages or README to paths that do not exist in the template tree (treat `FOO.md.template` as satisfying `FOO.md`).
+2. **No stub lint/test scripts** that always succeed or always fail without doing work.
+3. **Do not require M3** for new starters. Prefer M1; add M2 when the stack benefits from a sample domain feature.
+
+### 11.4 Related automation
+
+- Soft dependency warnings: `scripts/check-dependencies.js`
+- Registry validation: `scripts/validate-templates.js`
+- Prefer adding CI integrity checks (dead landing doc links, `shared/assets` drift) rather than relying on manual review alone.
+
+Track uplift work under [#290](https://github.com/Create-Node-App/cna-templates/issues/290).


### PR DESCRIPTION
## Summary
- Add **§11 Template maturity (M1/M2/M3)** to `docs/MAINTENANCE_TEMPLATES.md` with tiers, A–H checklist, and hard rules (no dead doc links, no stub lint/test)
- Point authors from `docs/AUTHORING.md`, `CONTRIBUTING.md`, and `docs/DEFAULT_LANDING_GUIDE.md`
- Gold refs: `react-vite-starter` / `nextjs-starter`; M3 SaaS is ceiling only

Closes #291 · Part of #290

## Test plan
- [ ] Skim §11 for clarity against actual gold templates
- [ ] Confirm CodeRabbit review on this docs PR
- [ ] No template code changes — docs only


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for adding and maintaining templates and extensions.
  * Added M1 maturity requirements and checklists for starter templates.
  * Clarified package configuration, interactive prompt placement, directory naming, and pull request checklist expectations.
  * Strengthened requirements for documentation links, testing, linting, and template reference examples.
  * Documented template maturity levels, review blockers, exceptions, and related automation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->