### PR TITLE
ci: template integrity checks + shared asset sync (#299)

### DIFF
--- a/.github/workflows/template-integrity.yml
+++ b/.github/workflows/template-integrity.yml
@@ -1,0 +1,38 @@
+name: Template Integrity
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integrity:
+    name: Template integrity checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Check landing/README doc links
+        run: node scripts/check-template-integrity.js
+
+      - name: Check shared assets sync
+        run: node scripts/sync-shared-assets.js --check

--- a/docs/DEFAULT_LANDING_GUIDE.md
+++ b/docs/DEFAULT_LANDING_GUIDE.md
@@ -21,7 +21,20 @@ The landing pages follow the CNA design system defined in [`DEFAULT_LANDING_DESI
 | `shared/assets/logo-mark-dark.svg` | Dark-background variant of the mark |
 | `shared/assets/favicon.svg` | Favicon source |
 
-When the identity changes, update the master files first, then copy them into each affected template.
+When the identity changes, update the master files first, then sync copies into templates:
+
+```bash
+node scripts/sync-shared-assets.js          # apply
+node scripts/sync-shared-assets.js --check  # CI drift check
+```
+
+**Landing documentation links must resolve** to files that exist in the template tree. CI enforces this via:
+
+```bash
+node scripts/check-template-integrity.js
+```
+
+(`FOO.md.template` satisfies a link to `FOO.md`.)
 
 ---
 

--- a/scripts/check-template-integrity.js
+++ b/scripts/check-template-integrity.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * Fail CI when UI landings / READMEs link to docs that do not exist in the template.
+ * Treats `FOO.md.template` as satisfying a link to `FOO.md`.
+ *
+ * Usage: node scripts/check-template-integrity.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const TEMPLATES_DIR = path.join(ROOT, "templates");
+
+const LANDING_BASENAMES = new Set([
+  "index.astro",
+  "Landing.tsx",
+  "Landing.tsx.template",
+  "page.tsx",
+  "page.tsx.template",
+  "_index.tsx",
+  "_index.tsx.template",
+  "Newtab.tsx",
+  "Newtab.tsx.template",
+]);
+
+const DOC_HREF_RE =
+  /(?:href|to)\s*[:=]\s*["'`](\.?\.?\/?docs\/[^"'`#?]+)["'`]/g;
+const MD_LINK_RE = /\[[^\]]*\]\((\.?\.?\/?docs\/[^)#?\s]+)\)/g;
+
+let failures = 0;
+
+function rel(p) {
+  return path.relative(ROOT, p);
+}
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".git") {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+function extractDocHrefs(content) {
+  const hrefs = new Set();
+  for (const re of [DOC_HREF_RE, MD_LINK_RE]) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(content)) !== null) {
+      let href = match[1].replace(/^\.\//, "").replace(/^\//, "");
+      if (href.startsWith("docs/")) hrefs.add(href);
+    }
+  }
+  return [...hrefs];
+}
+
+function docExists(templateRoot, docHref) {
+  const candidates = [
+    path.join(templateRoot, docHref),
+    path.join(templateRoot, `${docHref}.template`),
+  ];
+  // PROJECT_STRUCTURE.md.template under docs/
+  if (docHref.endsWith(".md")) {
+    candidates.push(path.join(templateRoot, `${docHref}.template`));
+  }
+  return candidates.some((p) => fs.existsSync(p));
+}
+
+function checkTemplate(templateName) {
+  const templateRoot = path.join(TEMPLATES_DIR, templateName);
+  const files = walk(templateRoot);
+  const targets = files.filter((f) => {
+    const base = path.basename(f);
+    if (LANDING_BASENAMES.has(base)) return true;
+    if (base === "README.md" || base === "README.md.template") return true;
+    if (base === "CONTRIBUTING.md" || base === "CONTRIBUTING.md.template") return true;
+    return false;
+  });
+
+  for (const file of targets) {
+    const content = fs.readFileSync(file, "utf8");
+    const hrefs = extractDocHrefs(content);
+    for (const href of hrefs) {
+      if (!docExists(templateRoot, href)) {
+        console.error(`❌ ${rel(file)} → missing ${href} (and ${href}.template)`);
+        failures += 1;
+      }
+    }
+  }
+}
+
+function main() {
+  console.log("🔍 Checking template landing/README doc link integrity...\n");
+
+  const templates = fs
+    .readdirSync(TEMPLATES_DIR)
+    .filter((name) => fs.statSync(path.join(TEMPLATES_DIR, name)).isDirectory());
+
+  for (const name of templates) {
+    checkTemplate(name);
+  }
+
+  console.log("\n" + "=".repeat(50));
+  if (failures > 0) {
+    console.error(`Found ${failures} broken doc link(s).`);
+    process.exit(1);
+  }
+  console.log("✅ All scanned doc links resolve.");
+  process.exit(0);
+}
+
+main();

--- a/scripts/sync-shared-assets.js
+++ b/scripts/sync-shared-assets.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Copy shared CNA brand assets into template public paths.
+ *
+ * Usage:
+ *   node scripts/sync-shared-assets.js           # apply copies
+ *   node scripts/sync-shared-assets.js --check    # exit 1 if drift
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const SHARED = path.join(ROOT, "shared", "assets");
+
+/**
+ * Map shared master → template-relative destinations.
+ * Keep in sync with docs/DEFAULT_LANDING_GUIDE.md.
+ */
+const COPIES = [
+  {
+    from: "logo-mark.svg",
+    to: [
+      "templates/astro-starter/public/logo.svg",
+      "templates/remix-starter/public/logo.svg",
+      "templates/react-vite-starter/public/logo.svg",
+      "templates/nextjs-starter/public/logo.svg",
+      "templates/webextension-react-vite-starter/public/logo.svg",
+      "templates/webextension-react-vite-starter/[src]/assets/img/logo.svg",
+    ],
+  },
+  {
+    from: "favicon.svg",
+    to: [
+      "templates/astro-starter/public/favicon.svg",
+      "templates/remix-starter/public/favicon.svg",
+      "templates/react-vite-starter/public/favicon.svg",
+      "templates/nextjs-starter/[src]/app/favicon.svg",
+      "templates/webextension-react-vite-starter/public/favicon.svg",
+    ],
+  },
+];
+
+const checkOnly = process.argv.includes("--check");
+let drift = 0;
+
+function ensureDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function main() {
+  console.log(
+    checkOnly
+      ? "🔍 Checking shared asset sync...\n"
+      : "📦 Syncing shared assets into templates...\n",
+  );
+
+  for (const { from, to } of COPIES) {
+    const src = path.join(SHARED, from);
+    if (!fs.existsSync(src)) {
+      console.error(`❌ Missing shared asset: shared/assets/${from}`);
+      process.exit(1);
+    }
+    const srcBuf = fs.readFileSync(src);
+
+    for (const relDest of to) {
+      const dest = path.join(ROOT, relDest);
+      if (checkOnly) {
+        if (!fs.existsSync(dest)) {
+          console.error(`❌ Missing copy: ${relDest}`);
+          drift += 1;
+          continue;
+        }
+        const destBuf = fs.readFileSync(dest);
+        if (!srcBuf.equals(destBuf)) {
+          console.error(`❌ Drift: ${relDest} differs from shared/assets/${from}`);
+          drift += 1;
+        } else {
+          console.log(`✅ ${relDest}`);
+        }
+      } else {
+        ensureDir(dest);
+        fs.writeFileSync(dest, srcBuf);
+        console.log(`→ ${relDest}`);
+      }
+    }
+  }
+
+  console.log("\n" + "=".repeat(50));
+  if (checkOnly) {
+    if (drift > 0) {
+      console.error(`${drift} asset path(s) out of sync. Run: node scripts/sync-shared-assets.js`);
+      process.exit(1);
+    }
+    console.log("✅ Shared assets in sync.");
+    process.exit(0);
+  }
+  console.log("✅ Sync complete.");
+}
+
+main();

--- a/templates/astro-starter/docs/COMPONENTS_AND_STYLING.md
+++ b/templates/astro-starter/docs/COMPONENTS_AND_STYLING.md
@@ -1,0 +1,3 @@
+# Components and Styling
+
+How UI is organized and styled in this starter. Expand with real patterns as the template reaches M1 (#290).

--- a/templates/astro-starter/docs/PROJECT_STRUCTURE.md
+++ b/templates/astro-starter/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,3 @@
+# Project Structure
+
+High-level layout for this starter. Replace this stub with a full guided tour of directories and conventions (maturity epic #290).

--- a/templates/astro-starter/docs/README.md
+++ b/templates/astro-starter/docs/README.md
@@ -1,0 +1,9 @@
+# Extra Documentation
+
+Project docs for this CNA starter. Expand these stubs as the template matures (see Create-Node-App/cna-templates#290).
+
+## Resources
+
+- [Project Structure](./PROJECT_STRUCTURE.md)
+- [Components and Styling](./COMPONENTS_AND_STYLING.md)
+- [State Management](./STATE_MANAGEMENT.md)

--- a/templates/astro-starter/docs/STATE_MANAGEMENT.md
+++ b/templates/astro-starter/docs/STATE_MANAGEMENT.md
@@ -1,0 +1,3 @@
+# State Management
+
+State and data-loading conventions for this starter. Expand with framework-specific guidance (#290).

--- a/templates/nestjs-starter/docs/PROJECT_STRUCTURE.md
+++ b/templates/nestjs-starter/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,11 @@
+# Project Structure
+
+NestJS modular layout for this starter:
+
+- `src/main.ts` — bootstrap
+- `src/app.module.ts` — root module
+- `src/app.controller.ts` / `src/app.service.ts` — sample HTTP surface
+- `src/health/` — health check module
+- `test/` — e2e specs
+
+Expand this guide with deeper Nest conventions as part of the Nest M2 polish (Create-Node-App/cna-templates#295).

--- a/templates/remix-starter/docs/COMPONENTS_AND_STYLING.md
+++ b/templates/remix-starter/docs/COMPONENTS_AND_STYLING.md
@@ -1,0 +1,3 @@
+# Components and Styling
+
+How UI is organized and styled in this starter. Expand with real patterns as the template reaches M1 (#290).

--- a/templates/remix-starter/docs/PROJECT_STRUCTURE.md
+++ b/templates/remix-starter/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,3 @@
+# Project Structure
+
+High-level layout for this starter. Replace this stub with a full guided tour of directories and conventions (maturity epic #290).

--- a/templates/remix-starter/docs/README.md
+++ b/templates/remix-starter/docs/README.md
@@ -1,0 +1,9 @@
+# Extra Documentation
+
+Project docs for this CNA starter. Expand these stubs as the template matures (see Create-Node-App/cna-templates#290).
+
+## Resources
+
+- [Project Structure](./PROJECT_STRUCTURE.md)
+- [Components and Styling](./COMPONENTS_AND_STYLING.md)
+- [State Management](./STATE_MANAGEMENT.md)

--- a/templates/remix-starter/docs/STATE_MANAGEMENT.md
+++ b/templates/remix-starter/docs/STATE_MANAGEMENT.md
@@ -1,0 +1,3 @@
+# State Management
+
+State and data-loading conventions for this starter. Expand with framework-specific guidance (#290).

--- a/templates/webextension-react-vite-starter/public/logo.svg
+++ b/templates/webextension-react-vite-starter/public/logo.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-labelledby="logoTitle logoDesc" role="img">
+  <title id="logoTitle">Create Awesome Node App</title>
+  <desc id="logoDesc">A cozy nest of three connected nodes forming the CNA mark.</desc>
+  <defs>
+    <linearGradient id="cnaNest" x1="10" y1="10" x2="54" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="55%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <!-- Cozy nest: three rounded nodes connected by thick strokes -->
+  <path
+    d="M32 10c-1.6 0-3.1.8-4 2.1l-11 17.6c-1.8 2.9-.3 6.7 3 7.5V46c0 3.3 2.7 6 6 6h12c3.3 0 6-2.7 6-6V37.2c3.3-.8 4.8-4.6 3-7.5L36 12.1C35.1 10.8 33.6 10 32 10Z"
+    stroke="url(#cnaNest)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+  />
+  <circle cx="32" cy="27" r="5" fill="#f59e0b"/>
+  <circle cx="20" cy="43" r="5" fill="#0d9488"/>
+  <circle cx="44" cy="43" r="5" fill="#d97706"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add `scripts/check-template-integrity.js` — fails when landings/READMEs link to missing `docs/*` (`.template` counts)
- Add `scripts/sync-shared-assets.js` (+ `--check`) for `shared/assets` → template public logos/favicons
- Wire both in `.github/workflows/template-integrity.yml`
- Minimal stub `docs/` for Astro/Remix + Nest `PROJECT_STRUCTURE.md` so integrity is green (full content in #293/#294/#295)
- Sync missing WebExt `public/logo.svg`

Closes #299 · Part of #290

## Test plan
- [x] `node scripts/check-template-integrity.js`
- [x] `node scripts/sync-shared-assets.js --check`
- [ ] CodeRabbit review
- [ ] Workflow runs green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added starter documentation covering project structure, components and styling, state management, and additional resources for Astro, Remix, and NestJS templates.
  * Clarified guidance for maintaining shared assets and documentation links.

* **Quality Improvements**
  * Added automated checks to detect broken template documentation links.
  * Added validation to ensure shared branding assets remain synchronized across templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->