### PR TITLE
feat(webextension): Vitest, Options scaffold, message-passing (#297)

### DIFF
--- a/templates/webextension-react-vite-starter/CONTRIBUTING.md.template
+++ b/templates/webextension-react-vite-starter/CONTRIBUTING.md.template
@@ -38,7 +38,7 @@ See [docs/PROJECT_STRUCTURE.md](./docs/PROJECT_STRUCTURE.md). Contexts: backgrou
 Be explicit about what runs where. Content scripts shouldn’t import background-only APIs directly.
 
 ## Messaging Patterns
-Use structured message types. Avoid anonymous string channels. Centralize message enums or builders.
+Use structured message types in `<%= srcDir%>/shared/messages.ts`. Avoid anonymous string channels. The sample popup sends a typed `PING` message and the background listener in `<%= srcDir%>/background/messageHandler.ts` replies with `PONG` plus the current settings snapshot.
 
 ## Coding Standards
 - Strict TypeScript
@@ -52,7 +52,14 @@ Use structured message types. Avoid anonymous string channels. Centralize messag
 Prefer lightweight libs—bundle size matters for extension review.
 
 ## Testing
-Add integration tests where possible (e.g., mocks or e2e harness). Unit test pure helpers.
+Unit tests run with Vitest and React Testing Library:
+
+```sh
+<%= runCommand%> test
+<%= runCommand%> test:watch
+```
+
+`vitest.setup.ts` mocks `webextension-polyfill` so UI components can be tested in Node. Add integration or browser harness tests when you need to exercise real extension contexts.
 
 ## Publishing
 Update version + changelog. Validate manifest. Smoke test on target browsers.

--- a/templates/webextension-react-vite-starter/README.md.template
+++ b/templates/webextension-react-vite-starter/README.md.template
@@ -28,6 +28,7 @@ You can find useful information such as project structure, available scripts and
 - [eslint](https://eslint.org/) - Linting utility for JavaScript and JSX
 - [prettier](https://prettier.io/) - Opinionated code formatter
 - [web-ext](https://www.npmjs.com/package/web-ext) - A command line tool to help build, run, and test web extensions
+- [Vitest](https://vitest.dev/) - Unit tests with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 
 ## Quickstart
 
@@ -54,7 +55,7 @@ While developing, you will probably rely mostly on `<%= runCommand%> start`; how
 | `<%= runCommand%> <script>` | Description                                                                                                             |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `dev`                       | Serves your app at for local development                                                                                |
-| `test`                      | Runs unit tests with Jest. See [testing](#testing)                                                                      |
+| `test`                      | Runs unit tests with Vitest. See [testing](#testing)                                                                    |
 | `test:watch`                | Runs `test` in watch mode to re-run tests when changed                                                                  |
 | `format`                    | Formats the project using [Prettier](https://prettier.io/)                                                              |
 | `lint`                      | [Lints](http://stackoverflow.com/questions/8503559/what-is-linting) the project for potential errors                    |
@@ -67,6 +68,21 @@ Available scripts:
 | `<%= runCommand%> <script>` | Description                                                                                                 |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `build`                     | Builds the application to `dist/`                                                                           |
+
+## Testing
+
+Unit tests use [Vitest](https://vitest.dev/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/). Extension APIs such as `browser.storage` and `browser.runtime` are mocked in `vitest.setup.ts`.
+
+```sh
+<%= runCommand%> test
+<%= runCommand%> test:watch
+```
+
+The starter includes a sample test for the options page. Add browser-level integration tests separately when you need to exercise real extension contexts.
+
+## Messaging
+
+Popup ↔ background communication uses typed messages in `<%= srcDir%>/shared/messages.ts`. The background service worker registers a listener in `<%= srcDir%>/background/messageHandler.ts`. Use the popup's **Ping background** button to try the sample flow.
 
 ## Contributing
 

--- a/templates/webextension-react-vite-starter/[src]/background/index.ts
+++ b/templates/webextension-react-vite-starter/[src]/background/index.ts
@@ -1,5 +1,7 @@
 import reloadOnUpdate from 'virtual:reload-on-update-in-background-script';
 
+import { registerMessageListener } from '@/background/messageHandler';
+
 reloadOnUpdate('background');
 
 /**
@@ -7,5 +9,7 @@ reloadOnUpdate('background');
  * If you do not use the css of the content script, please delete it.
  */
 reloadOnUpdate('content/style.scss');
+
+registerMessageListener();
 
 console.log('background loaded');

--- a/templates/webextension-react-vite-starter/[src]/background/messageHandler.ts
+++ b/templates/webextension-react-vite-starter/[src]/background/messageHandler.ts
@@ -1,0 +1,36 @@
+import Browser from 'webextension-polyfill';
+
+import { getSettings } from '@/shared/settings';
+import type { ExtensionMessage, ExtensionResponse } from '@/shared/messages';
+import { isExtensionMessage } from '@/shared/messages';
+
+async function handleMessage(message: ExtensionMessage): Promise<ExtensionResponse> {
+  switch (message.type) {
+    case 'PING':
+      return {
+        type: 'PONG',
+        timestamp: Date.now(),
+        settings: await getSettings(),
+      };
+    default:
+      return {
+        type: 'ERROR',
+        message: 'Unsupported message type',
+      };
+  }
+}
+
+export function registerMessageListener(): void {
+  Browser.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
+    if (!isExtensionMessage(message)) {
+      sendResponse({
+        type: 'ERROR',
+        message: 'Invalid message payload',
+      } satisfies ExtensionResponse);
+      return false;
+    }
+
+    void handleMessage(message).then(sendResponse);
+    return true;
+  });
+}

--- a/templates/webextension-react-vite-starter/[src]/options/Options.css
+++ b/templates/webextension-react-vite-starter/[src]/options/Options.css
@@ -1,8 +1,102 @@
-.OptionsContainer {
-  width: 100%;
-  height: 50vh;
+.options {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #0f172a;
+}
+
+.options__header {
+  margin-bottom: 2rem;
+}
+
+.options__eyebrow {
+  margin: 0 0 0.35rem;
+  color: #b45309;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.options__title {
+  margin: 0 0 0.75rem;
   font-size: 2rem;
+}
+
+.options__lead {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.options__lead code {
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.options__form {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.options__field {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.options__field input {
+  padding: 0.75rem 0.85rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  font: inherit;
+}
+
+.options__checkbox {
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 0.65rem;
+  font-weight: 600;
+}
+
+.options__actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.options__button {
+  justify-self: start;
+  min-height: 42px;
+  padding: 0.65rem 1.25rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f59e0b, #0d9488);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.options__button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.options__status {
+  margin: 0;
+  color: #475569;
+}
+
+.options__status--success {
+  color: #047857;
+}
+
+.options__status--error {
+  color: #b91c1c;
 }

--- a/templates/webextension-react-vite-starter/[src]/options/Options.test.tsx
+++ b/templates/webextension-react-vite-starter/[src]/options/Options.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Browser from 'webextension-polyfill';
+
+import Options from '@/options/Options';
+import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY } from '@/shared/settings';
+
+describe('Options', () => {
+  it('loads saved settings from storage.sync', async () => {
+    vi.mocked(Browser.storage.sync.get).mockResolvedValue({
+      [SETTINGS_STORAGE_KEY]: {
+        ...DEFAULT_SETTINGS,
+        displayName: 'Test User',
+        enableNotifications: false,
+      },
+    });
+
+    render(<Options />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/display name/i)).toHaveValue('Test User');
+    });
+
+    expect(screen.getByLabelText(/enable notifications/i)).not.toBeChecked();
+  });
+});

--- a/templates/webextension-react-vite-starter/[src]/options/Options.tsx
+++ b/templates/webextension-react-vite-starter/[src]/options/Options.tsx
@@ -1,8 +1,96 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+import { DEFAULT_SETTINGS, getSettings, saveSettings, type ExtensionSettings } from '@/shared/settings';
 import '@/options/Options.css';
 
 const Options: React.FC = () => {
-  return <div className="OptionsContainer">Options</div>;
+  const [settings, setSettings] = useState<ExtensionSettings>(DEFAULT_SETTINGS);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'saving' | 'saved' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const storedSettings = await getSettings();
+        if (!cancelled) {
+          setSettings(storedSettings);
+          setStatus('idle');
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStatus('error');
+          setErrorMessage(error instanceof Error ? error.message : 'Failed to load settings');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('saving');
+    setErrorMessage('');
+
+    try {
+      await saveSettings(settings);
+      setStatus('saved');
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to save settings');
+    }
+  };
+
+  return (
+    <div className="options">
+      <header className="options__header">
+        <p className="options__eyebrow">Extension settings</p>
+        <h1 className="options__title">Options</h1>
+        <p className="options__lead">Preferences are stored with <code>browser.storage.sync</code> via webextension-polyfill.</p>
+      </header>
+
+      {status === 'loading' ? (
+        <p className="options__status">Loading settings…</p>
+      ) : (
+        <form className="options__form" onSubmit={handleSubmit}>
+          <label className="options__field">
+            <span>Display name</span>
+            <input
+              type="text"
+              value={settings.displayName}
+              aria-label="Display name"
+              placeholder="How should the extension greet you?"
+              onChange={(event) => setSettings((current) => ({ ...current, displayName: event.target.value }))}
+            />
+          </label>
+
+          <label className="options__checkbox">
+            <input
+              type="checkbox"
+              checked={settings.enableNotifications}
+              aria-label="Enable notifications"
+              onChange={(event) =>
+                setSettings((current) => ({ ...current, enableNotifications: event.target.checked }))
+              }
+            />
+            <span>Enable notifications</span>
+          </label>
+
+          <div className="options__actions">
+            <button type="submit" className="options__button" disabled={status === 'saving'}>
+              {status === 'saving' ? 'Saving…' : 'Save settings'}
+            </button>
+            {status === 'saved' ? <p className="options__status options__status--success">Settings saved.</p> : null}
+            {status === 'error' ? <p className="options__status options__status--error">{errorMessage}</p> : null}
+          </div>
+        </form>
+      )}
+    </div>
+  );
 };
 
 export default Options;

--- a/templates/webextension-react-vite-starter/[src]/popup/Popup.css
+++ b/templates/webextension-react-vite-starter/[src]/popup/Popup.css
@@ -96,3 +96,26 @@
   cursor: not-allowed;
   filter: none;
 }
+
+.popup__button--secondary {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--popup-text);
+  border: 1px solid var(--popup-border);
+}
+
+.popup__feedback {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  line-height: 1.5;
+}
+
+.popup__feedback--success {
+  background: rgba(13, 148, 136, 0.16);
+  color: #99f6e4;
+}
+
+.popup__feedback--error {
+  background: rgba(239, 68, 68, 0.16);
+  color: #fecaca;
+}

--- a/templates/webextension-react-vite-starter/[src]/popup/Popup.tsx.template
+++ b/templates/webextension-react-vite-starter/[src]/popup/Popup.tsx.template
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Browser from 'webextension-polyfill';
 import logo from '@/assets/img/logo.svg';
-import { sendExtensionMessage, type PingResponse } from '@/shared/messages';
+import { usePingBackground } from '@/popup/usePingBackground';
 import '@/popup/Popup.css';
 
 const openOptions = () => {
@@ -13,23 +13,7 @@ const openOptions = () => {
 const canOpenOptions = Boolean(Browser.runtime.openOptionsPage);
 
 const Popup = () => {
-  const [pingStatus, setPingStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [pingMessage, setPingMessage] = useState('');
-
-  const pingBackground = async () => {
-    setPingStatus('loading');
-    setPingMessage('');
-
-    try {
-      const response = await sendExtensionMessage<PingResponse>({ type: 'PING' });
-      const greeting = response.settings.displayName.trim() || 'there';
-      setPingStatus('success');
-      setPingMessage(`Background replied at ${new Date(response.timestamp).toLocaleTimeString()} — hello, ${greeting}!`);
-    } catch (error) {
-      setPingStatus('error');
-      setPingMessage(error instanceof Error ? error.message : 'Background did not respond');
-    }
-  };
+  const { pingStatus, pingMessage, pingBackground } = usePingBackground();
 
   return (
     <div className="popup">
@@ -56,12 +40,24 @@ const Popup = () => {
           </p>
         </div>
 
-        <button type="button" className="popup__button popup__button--secondary" onClick={pingBackground} disabled={pingStatus === 'loading'}>
+        <button
+          type="button"
+          className="popup__button popup__button--secondary"
+          onClick={pingBackground}
+          disabled={pingStatus === 'loading'}
+        >
           {pingStatus === 'loading' ? 'Pinging background…' : 'Ping background'}
         </button>
 
         {pingMessage ? (
-          <p className={`popup__feedback popup__feedback--${pingStatus === 'success' ? 'success' : 'error'}`}>{pingMessage}</p>
+          <p
+            className={
+              'popup__feedback popup__feedback--' +
+              (pingStatus === 'success' ? 'success' : 'error')
+            }
+          >
+            {pingMessage}
+          </p>
         ) : null}
 
         <button type="button" className="popup__button" onClick={openOptions} disabled={!canOpenOptions}>

--- a/templates/webextension-react-vite-starter/[src]/popup/Popup.tsx.template
+++ b/templates/webextension-react-vite-starter/[src]/popup/Popup.tsx.template
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Browser from 'webextension-polyfill';
 import logo from '@/assets/img/logo.svg';
+import { sendExtensionMessage, type PingResponse } from '@/shared/messages';
 import '@/popup/Popup.css';
 
 const openOptions = () => {
@@ -12,6 +13,24 @@ const openOptions = () => {
 const canOpenOptions = Boolean(Browser.runtime.openOptionsPage);
 
 const Popup = () => {
+  const [pingStatus, setPingStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [pingMessage, setPingMessage] = useState('');
+
+  const pingBackground = async () => {
+    setPingStatus('loading');
+    setPingMessage('');
+
+    try {
+      const response = await sendExtensionMessage<PingResponse>({ type: 'PING' });
+      const greeting = response.settings.displayName.trim() || 'there';
+      setPingStatus('success');
+      setPingMessage(`Background replied at ${new Date(response.timestamp).toLocaleTimeString()} — hello, ${greeting}!`);
+    } catch (error) {
+      setPingStatus('error');
+      setPingMessage(error instanceof Error ? error.message : 'Background did not respond');
+    }
+  };
+
   return (
     <div className="popup">
       <div className="popup__surface">
@@ -33,9 +52,17 @@ const Popup = () => {
             Edit <code><%= srcDir%>/popup/Popup.tsx</code>
           </p>
           <p>
-            Configure <code><%= srcDir%>/options/Options.tsx</code>
+            Messaging lives in <code><%= srcDir%>/shared/messages.ts</code>
           </p>
         </div>
+
+        <button type="button" className="popup__button popup__button--secondary" onClick={pingBackground} disabled={pingStatus === 'loading'}>
+          {pingStatus === 'loading' ? 'Pinging background…' : 'Ping background'}
+        </button>
+
+        {pingMessage ? (
+          <p className={`popup__feedback popup__feedback--${pingStatus === 'success' ? 'success' : 'error'}`}>{pingMessage}</p>
+        ) : null}
 
         <button type="button" className="popup__button" onClick={openOptions} disabled={!canOpenOptions}>
           {canOpenOptions ? 'Open options' : 'Options unavailable'}

--- a/templates/webextension-react-vite-starter/[src]/popup/usePingBackground.ts
+++ b/templates/webextension-react-vite-starter/[src]/popup/usePingBackground.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { sendExtensionMessage, type PingResponse } from '@/shared/messages';
+
+export type PingUiStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export function usePingBackground() {
+  const [pingStatus, setPingStatus] = useState<PingUiStatus>('idle');
+  const [pingMessage, setPingMessage] = useState('');
+
+  const pingBackground = async () => {
+    setPingStatus('loading');
+    setPingMessage('');
+
+    try {
+      const response = await sendExtensionMessage<PingResponse>({ type: 'PING' });
+      if (!response || response.type !== 'PONG') {
+        throw new Error('Unexpected background response');
+      }
+      const greeting = response.settings.displayName.trim() || 'there';
+      const when = new Date(response.timestamp).toLocaleTimeString();
+      setPingStatus('success');
+      setPingMessage(
+        'Background replied at ' + when + ' — hello, ' + greeting + '!',
+      );
+    } catch (error) {
+      setPingStatus('error');
+      setPingMessage(error instanceof Error ? error.message : 'Background did not respond');
+    }
+  };
+
+  return { pingStatus, pingMessage, pingBackground };
+}

--- a/templates/webextension-react-vite-starter/[src]/shared/messages.ts
+++ b/templates/webextension-react-vite-starter/[src]/shared/messages.ts
@@ -1,0 +1,30 @@
+import Browser from 'webextension-polyfill';
+
+import type { ExtensionSettings } from '@/shared/settings';
+
+export type PingMessage = {
+  type: 'PING';
+};
+
+export type PingResponse = {
+  type: 'PONG';
+  timestamp: number;
+  settings: ExtensionSettings;
+};
+
+export type ErrorResponse = {
+  type: 'ERROR';
+  message: string;
+};
+
+export type ExtensionMessage = PingMessage;
+export type ExtensionResponse = PingResponse | ErrorResponse;
+
+export function isExtensionMessage(message: unknown): message is ExtensionMessage {
+  return typeof message === 'object' && message !== null && 'type' in message && (message as PingMessage).type === 'PING';
+}
+
+export async function sendExtensionMessage<T extends ExtensionResponse>(message: ExtensionMessage): Promise<T> {
+  const response = await Browser.runtime.sendMessage(message);
+  return response as T;
+}

--- a/templates/webextension-react-vite-starter/[src]/shared/settings.ts
+++ b/templates/webextension-react-vite-starter/[src]/shared/settings.ts
@@ -1,0 +1,27 @@
+import Browser from 'webextension-polyfill';
+
+export const SETTINGS_STORAGE_KEY = 'extensionSettings';
+
+export interface ExtensionSettings {
+  enableNotifications: boolean;
+  displayName: string;
+}
+
+export const DEFAULT_SETTINGS: ExtensionSettings = {
+  enableNotifications: true,
+  displayName: '',
+};
+
+export async function getSettings(): Promise<ExtensionSettings> {
+  const stored = await Browser.storage.sync.get(SETTINGS_STORAGE_KEY);
+  const value = stored[SETTINGS_STORAGE_KEY] as Partial<ExtensionSettings> | undefined;
+
+  return {
+    ...DEFAULT_SETTINGS,
+    ...value,
+  };
+}
+
+export async function saveSettings(settings: ExtensionSettings): Promise<void> {
+  await Browser.storage.sync.set({ [SETTINGS_STORAGE_KEY]: settings });
+}

--- a/templates/webextension-react-vite-starter/docs/PROJECT_STRUCTURE.md.template
+++ b/templates/webextension-react-vite-starter/docs/PROJECT_STRUCTURE.md.template
@@ -23,6 +23,8 @@ Most of the code lives in the `src` and `.webext-config` folders. The `src` fold
 |
 +-- panel # panel scripts
 |
++-- shared # cross-context helpers (settings, typed messages)
+|
 +-- popup # popup scripts
 ```
 
@@ -57,6 +59,10 @@ The `options` folder contains the options scripts. The options scripts are injec
 ## 📦 Panel
 
 The `panel` folder contains the panel scripts. The panel scripts are injected into the panel page. They can be used to listen for events and to send messages to the background script.
+
+## 📦 Shared
+
+The `shared` folder contains helpers used across extension contexts, such as typed runtime messages and `browser.storage` settings helpers.
 
 ## 📦 Popup
 

--- a/templates/webextension-react-vite-starter/docs/README.md
+++ b/templates/webextension-react-vite-starter/docs/README.md
@@ -9,6 +9,8 @@ This folder contains detailed documentation for the Web Extension + React templa
 - [Components and Styling](./COMPONENTS_AND_STYLING.md) - Best practices for components and styling solutions
 - [Performance](./PERFORMANCE.md) - Performance optimization guidelines for web extensions
 - [State Management](./STATE_MANAGEMENT.md) - State management patterns and recommendations
+- [Testing](../README.md#testing) - Vitest setup, mocks, and sample tests
+- [Messaging](../README.md#messaging) - Typed popup ↔ background message passing
 
 ## Web Extension Specific Resources
 
@@ -19,6 +21,8 @@ This folder contains detailed documentation for the Web Extension + React templa
 ## Development Tools
 
 - [Vite Documentation](https://vitejs.dev/guide/)
+- [Vitest Documentation](https://vitest.dev/guide/)
+- [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 - [React Documentation](https://reactjs.org/docs/getting-started.html)
 - [TypeScript Documentation](https://www.typescriptlang.org/docs/)
 

--- a/templates/webextension-react-vite-starter/eslint.config.mjs.template
+++ b/templates/webextension-react-vite-starter/eslint.config.mjs.template
@@ -23,6 +23,8 @@ export default [
       'release',
       'electron',
       'postcss.config.js',
+      'vitest.config.ts',
+      'vitest.setup.ts',
     ],
   },
   {

--- a/templates/webextension-react-vite-starter/manifest.ts.template
+++ b/templates/webextension-react-vite-starter/manifest.ts.template
@@ -6,6 +6,7 @@ const manifest: Manifest.WebExtensionManifest = {
   name: packageJson.name,
   version: packageJson.version,
   description: packageJson.description,
+  permissions: ['storage'],
   options_ui: {
     page: '<%= srcDir%>/options/index.html',
   },

--- a/templates/webextension-react-vite-starter/package/devDependencies.js
+++ b/templates/webextension-react-vite-starter/package/devDependencies.js
@@ -1,5 +1,7 @@
 module.exports = {
   '@eslint/js': '^9.39.4',
+  '@testing-library/jest-dom': '^6.9.1',
+  '@testing-library/react': '^16.3.2',
   '@types/node': '^26.1.0',
   '@types/react': '^19.2.17',
   '@types/react-dom': '^19.2.3',
@@ -12,6 +14,7 @@ module.exports = {
   'eslint-plugin-jsx-a11y': '^6.10.2',
   'eslint-plugin-prettier': '^5.5.6',
   'identity-obj-proxy': '^3.0.0',
+  jsdom: '^26.1.0',
   'npm-run-all': '^4.1.5',
   prettier: '^3.9.4',
   sass: '^1.101.0',
@@ -19,6 +22,7 @@ module.exports = {
   typescript: '^6.0.3',
   'typescript-eslint': '^8.62.1',
   vite: '^6.4.3',
+  vitest: '^3.2.4',
   'vite-plugin-eslint': '^1.8.1',
   'web-ext': '^9.4.0',
   ws: '^8.18.0',

--- a/templates/webextension-react-vite-starter/package/index.js
+++ b/templates/webextension-react-vite-starter/package/index.js
@@ -31,6 +31,8 @@ module.exports = function resolvePackage(setup, { appName, runCommand }) {
       "web-ext:firefox":
         "web-ext run --source-dir ./dist --target=firefox-desktop",
       "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json",
+      test: "vitest run",
+      "test:watch": "vitest",
     },
   };
 

--- a/templates/webextension-react-vite-starter/vitest.config.ts.template
+++ b/templates/webextension-react-vite-starter/vitest.config.ts.template
@@ -1,0 +1,18 @@
+import path from 'path';
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['<%= srcDir%>/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '<%= projectImportPath%>': path.resolve(__dirname, '<%= srcDir%>') + '/',
+    },
+  },
+});

--- a/templates/webextension-react-vite-starter/vitest.setup.ts.template
+++ b/templates/webextension-react-vite-starter/vitest.setup.ts.template
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      local: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    runtime: {
+      sendMessage: vi.fn(),
+      onMessage: {
+        addListener: vi.fn(),
+      },
+      openOptionsPage: vi.fn(),
+    },
+  },
+}));


### PR DESCRIPTION
## Summary
- Real Vitest (+ RTL) wired as `test` / `test:watch` (no fake Jest README claims)
- Options page settings scaffold with storage get/set
- Typed popup ↔ background message-passing sample

Closes #297 · Part of #290

## Test plan
- [ ] CodeRabbit review
- [ ] `npm test` after scaffold
- [ ] Options + messaging smoke manually if needed

Made with [Cursor](https://cursor.com)