### PR TITLE
chore(deps): apply non-breaking dependabot bumps

### DIFF
--- a/extensions/nestjs-drizzle-sqlite/package.json
+++ b/extensions/nestjs-drizzle-sqlite/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "drizzle-orm": "0.45.2",
-    "better-sqlite3": "^12.11.1"
+    "better-sqlite3": "^13.0.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/extensions/nextjs-auth/package.json
+++ b/extensions/nextjs-auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs-auth-extension",
   "dependencies": {
-    "next-auth": "5.0.0-beta.31"
+    "next-auth": "5.0.0-beta.32"
   },
   "devDependencies": {}
 }

--- a/extensions/react-semantic-ui-less/package.json
+++ b/extensions/react-semantic-ui-less/package.json
@@ -5,6 +5,6 @@
   },
   "devDependencies": {
     "less": "^4.2.0",
-    "less-loader": "^12.2.0"
+    "less-loader": "^13.0.0"
   }
 }

--- a/extensions/react-testing-library-with-jest/package.json
+++ b/extensions/react-testing-library-with-jest/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.2.0",
     "@types/jest": "^30.0.0",
     "eslint-plugin-jest": "^29.12.1",

--- a/extensions/react-testing-library-with-vitest/package.json
+++ b/extensions/react-testing-library-with-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitest/coverage-v8": "^4.1.9",


### PR DESCRIPTION
Applies the safe, non-breaking parts of PRs #315 and #316 (now closed):

| Extension | Dependency | From → To |
|---|---|---|
| react-testing-library-with-jest | @testing-library/jest-dom | ^6.6.3 → ^7.0.0 |
| react-testing-library-with-vitest | @testing-library/jest-dom | ^6.6.3 → ^7.0.0 |
| react-semantic-ui-less | less-loader | ^12.2.0 → ^13.0.0 |
| nestjs-drizzle-sqlite | better-sqlite3 | ^12.11.1 → ^13.0.1 |
| nextjs-auth | next-auth | 5.0.0-beta.31 → 5.0.0-beta.32 |

All bumps verified: versions exist on npm, no API changes in generated scaffolds.

Breaking changes that were in the original PRs are now tracked separately:
- #317 — tailwindcss v4 (CSS-based config)
- #318 — prisma 7 (schema migration, prisma.config.ts)
- feat/storybook-v10-migration — Storybook v10 complete migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting libraries for SQLite, authentication, styling, and testing to newer versions.
  * Improved compatibility with current development and runtime tooling.
  * Applied minor package configuration formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->