### PR TITLE
feat: migrate react-tailwindcss and react-shadcn to tailwindcss v4

### DIFF
--- a/extensions/react-shadcn/[src]/theme/global.css.template
+++ b/extensions/react-shadcn/[src]/theme/global.css.template
@@ -1,13 +1,29 @@
-/* shadcn/ui global styles (templated) */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@plugin "tailwindcss-animate";
+
+@theme {
+  --color-bg: rgb(var(--color-bg));
+  --color-fg: rgb(var(--color-fg));
+  --animate-fade-in: fade-in .2s ease-out;
+  --animate-scale-in: scale-in .25s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: translate(-50%, -48%) scale(.95); }
+  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
 
 :root {
   --radius: 8px;
   --color-bg: 255 252 245;
   --color-fg: 31 41 55;
 }
+
 .dark {
   --color-bg: 15 23 42;
   --color-fg: 248 250 252;

--- a/extensions/react-shadcn/package.json
+++ b/extensions/react-shadcn/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "tailwindcss": "^3.4.0",
+    "@tailwindcss/postcss": "^4.3.3",
+    "tailwindcss": "^4.3.3",
+    "tailwindcss-animate": "^1.0.7",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.0",

--- a/extensions/react-shadcn/postcss.config.js.template
+++ b/extensions/react-shadcn/postcss.config.js.template
@@ -1,17 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
-
-/**
- * PostCSS config function — uses ctx.cwd to resolve tailwindcss from the
- * project root even when npm nests it due to legacy-peer-deps interactions.
- */
-module.exports = (ctx) => {
-  const cwd = ctx.cwd || process.cwd();
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const tw = require(path.join(cwd, 'node_modules', 'tailwindcss'));
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const ap = require(path.join(cwd, 'node_modules', 'autoprefixer'));
-  return {
-    plugins: [tw, ap],
-  };
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };

--- a/extensions/react-shadcn/tailwind.config.js.template
+++ b/extensions/react-shadcn/tailwind.config.js.template
@@ -2,35 +2,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
-  content: [
-    './index.html',
-    './<%= srcDir %>/**/*.{js,ts,jsx,tsx}',
-  ],
-  theme: {
-    extend: {
-      borderRadius: {
-        lg: 'var(--radius)',
-        xl: 'calc(var(--radius) + 4px)'
-      },
-      colors: {
-        bg: 'rgb(var(--color-bg) / <alpha-value>)',
-        fg: 'rgb(var(--color-fg) / <alpha-value>)'
-      },
-      keyframes: {
-        'fade-in': {
-          from: { opacity: 0 },
-          to: { opacity: 1 }
-        },
-        'scale-in': {
-          from: { opacity: 0, transform: 'translate(-50%, -48%) scale(.95)' },
-          to: { opacity: 1, transform: 'translate(-50%, -50%) scale(1)' }
-        }
-      },
-      animation: {
-        'fade-in': 'fade-in .2s ease-out',
-        'scale-in': 'scale-in .25s ease-out'
-      }
-    }
-  },
-  plugins: []
+  content: ['./index.html', './<%= srcDir %>/**/*.{js,ts,jsx,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
 };

--- a/extensions/react-tailwindcss/[src]/theme/tailwind.css.template
+++ b/extensions/react-tailwindcss/[src]/theme/tailwind.css.template
@@ -1,17 +1,27 @@
-/* Tailwind base stylesheet (templated) */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@theme {
+  --color-brand-50: #f5f8ff;
+  --color-brand-100: #ebf1ff;
+  --color-brand-200: #d6e3ff;
+  --color-brand-300: #adc7ff;
+  --color-brand-400: #7aa5ff;
+  --color-brand-500: #3d7dff;
+  --color-brand-600: #1559e6;
+  --color-brand-700: #0f44b4;
+  --color-brand-800: #0d378f;
+  --color-brand-900: #0c2f75;
+  --radius-xl: 1rem;
+}
 
 :root {
   --radius: 8px;
 }
 
-html.dark { color-scheme: dark; }
+body {
+  @apply bg-white text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100 antialiased;
+}
 
-body { @apply bg-white text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100 antialiased; }
-
-/* Example utility composition */
 .btn-primary {
   @apply inline-flex items-center rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white shadow hover:bg-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors;
 }

--- a/extensions/react-tailwindcss/package.json
+++ b/extensions/react-tailwindcss/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "tailwindcss": "^3.4.0",
+    "@tailwindcss/postcss": "^4.3.3",
+    "tailwindcss": "^4.3.3",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20"
   }

--- a/extensions/react-tailwindcss/postcss.config.js.template
+++ b/extensions/react-tailwindcss/postcss.config.js.template
@@ -1,17 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
-
-/**
- * PostCSS config function — uses ctx.cwd to resolve tailwindcss from the
- * project root even when npm nests it due to legacy-peer-deps interactions.
- */
-module.exports = (ctx) => {
-  const cwd = ctx.cwd || process.cwd();
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const tw = require(path.join(cwd, 'node_modules', 'tailwindcss'));
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const ap = require(path.join(cwd, 'node_modules', 'autoprefixer'));
-  return {
-    plugins: [tw, ap],
-  };
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
 };

--- a/extensions/react-tailwindcss/tailwind.config.js.template
+++ b/extensions/react-tailwindcss/tailwind.config.js.template
@@ -1,30 +1,7 @@
-/**
- * Tailwind CSS Config
- */
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
   content: ['./index.html', '<%= srcDir %>/**/*.{js,ts,jsx,tsx}'],
-  theme: {
-    extend: {
-      colors: {
-        brand: {
-          50: '#f5f8ff',
-          100: '#ebf1ff',
-          200: '#d6e3ff',
-          300: '#adc7ff',
-          400: '#7aa5ff',
-          500: '#3d7dff',
-          600: '#1559e6',
-          700: '#0f44b4',
-          800: '#0d378f',
-          900: '#0c2f75',
-        },
-      },
-      borderRadius: {
-        xl: '1rem',
-      },
-    },
-  },
+  theme: { extend: {} },
   plugins: [],
 };

--- a/templates/react-vite-starter/package/devDependencies.js
+++ b/templates/react-vite-starter/package/devDependencies.js
@@ -20,8 +20,4 @@ module.exports = {
   'vite-plugin-eslint': '^1.8.1',
   'vite-plugin-pwa': '^1.3.0',
   'less': '^4.2.0',
-  '@tailwindcss/postcss': '^4.3.3',
-  'tailwindcss': '^4.3.3',
-  'postcss': '^8.4.47',
-  'autoprefixer': '^10.4.20',
 };

--- a/templates/react-vite-starter/package/devDependencies.js
+++ b/templates/react-vite-starter/package/devDependencies.js
@@ -20,7 +20,8 @@ module.exports = {
   'vite-plugin-eslint': '^1.8.1',
   'vite-plugin-pwa': '^1.3.0',
   'less': '^4.2.0',
-  'tailwindcss': '^3.4.0',
+  '@tailwindcss/postcss': '^4.3.3',
+  'tailwindcss': '^4.3.3',
   'postcss': '^8.4.47',
   'autoprefixer': '^10.4.20',
 };


### PR DESCRIPTION
## Summary

Migrates the React tailwindcss v3 extensions to tailwindcss v4.

## Changes

- `react-tailwindcss` and `react-shadcn` extensions updated
- PostCSS config: function-based `(ctx) => { plugins: [tw, ap] }` → object-based `plugins: { '@tailwindcss/postcss': {}, autoprefixer: {} }`
- CSS: `@tailwind base/components/utilities` → `@import "tailwindcss"` + `@theme` block
- Brand palette and custom animations moved from `tailwind.config.js` theme.extend into CSS `@theme`
- `tailwind.config.js` kept minimal: `darkMode: 'class'` + `content` globs
- Template `devDependencies.js`: `tailwindcss` ^3.4.0 → ^4.3.3, added `@tailwindcss/postcss`

## Testing

- `react-tailwindcss` scaffold: `npm install` + `npm run build` ✅
- `react-shadcn` scaffold: `npm install` + `npm run build` ✅
- Both combined: `npm install` + `npm run build` ✅

Closes #317