### PR TITLE
fix(ci): point Dependabot at real npm manifests only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
+  # Template roots ship deps via package/index.js (no package.json on disk).
+  # Only scan extension manifests and the SaaS danger tooling package.
   - package-ecosystem: npm
     directories:
       - /extensions/*
-      - /templates/*
+      - /templates/nextjs-saas-ai-starter/tools/danger
     schedule:
       interval: weekly
     groups:
@@ -11,3 +13,12 @@ updates:
         dependency-type: development
       productionDependencies:
         dependency-type: production
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Stop Dependabot from scanning `/templates/*` roots that have no `package.json` (deps are generated from `package/index.js`).
- Keep npm updates for `/extensions/*` and the SaaS `tools/danger` package.
- Add weekly `github-actions` updates to match cpa-templates hygiene.

## Why
Dependabot security jobs on main were failing with `dependency_file_not_found` for `/templates/nextjs-saas-ai-starter` (brace-expansion / js-yaml), polluting Actions history.

## Test plan
- [ ] PR CI (L0–L3) green
- [ ] After merge, Dependabot no longer schedules updates against bare template roots

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency scanning coverage.
  * Added weekly checks for GitHub Actions dependencies.
  * Grouped GitHub Actions dependency updates for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->