### PR TITLE
chore(ci): ignore Prisma major bumps until extension migrates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
       - /templates/nextjs-saas-ai-starter/tools/danger
     schedule:
       interval: weekly
+    ignore:
+      # Prisma 7 needs schema/config migration in nextjs-prisma.
+      - dependency-name: prisma
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@prisma/client"
+        update-types: ["version-update:semver-major"]
     groups:
       devDependencies:
         dependency-type: development


### PR DESCRIPTION
## Summary
- Ignore semver-major Dependabot updates for `prisma` and `@prisma/client`.
- Prevents reopening broken PRs like #324/#325 until `nextjs-prisma` migrates to Prisma 7 config.

## Test plan
- [ ] CI green
- [ ] Dependabot no longer opens Prisma 7 majors for this ecosystem entry

Made with [Cursor](https://cursor.com)