### PR TITLE
docs: add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![L3 Profiles](https://github.com/Create-Node-App/cna-templates/actions/workflows/ci-profiles.yml/badge.svg)](https://github.com/Create-Node-App/cna-templates/actions/workflows/ci-profiles.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Node Version](https://img.shields.io/badge/node-22+-green.svg)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 This repository contains official templates and extensions for [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app).
 


### PR DESCRIPTION
## Summary
- Add Discord community badge linking to https://discord.gg/dwFTsR7fK2
- Place it with existing README badges (or under the title when none exist), matching each README's badge style

## Test plan
- [ ] Confirm badge renders on GitHub README preview
- [ ] Confirm click opens Discord invite
- [ ] Confirm member count shield loads (server ID 1527933660764831825)
