### PR TITLE
docs(nextjs-i18n): add extension README

### DIFF
--- a/extensions/nextjs-i18n/README.md
+++ b/extensions/nextjs-i18n/README.md
@@ -1,0 +1,37 @@
+# next-intl (i18n) for Next.js
+
+Adds [next-intl](https://next-intl.dev/) internationalization to a Next.js App Router project, with English and Spanish messages, locale routing, and typed locale configuration.
+
+## Compatibility
+
+This extension is compatible with templates whose type is `nextjs`.
+
+## Apply
+
+```sh
+npx create-awesome-node-app my-app --template nextjs-starter --addons nextjs-i18n
+```
+
+## What it adds
+
+- `messages/en.json` and `messages/es.json` — starter English and Spanish messages
+- `src/i18n/config.ts` — supported locales, the default locale, and the `Locale` type
+- `src/i18n/request.ts` — request locale validation and message loading
+- `src/i18n/client.ts` — client-side next-intl hook exports
+- `src/middleware-handlers.ts` — locale-aware request middleware
+- `next.config.mjs` — next-intl plugin configuration
+- `next-intl` — runtime dependency
+
+## Verify
+
+After scaffolding the app, install dependencies and run a production build:
+
+```sh
+cd my-app
+npm install
+npm run build
+```
+
+## Resources
+
+- [next-intl documentation](https://next-intl.dev/docs/getting-started/app-router)


### PR DESCRIPTION
## Summary

- document what the `nextjs-i18n` extension adds
- record its `nextjs` template compatibility and scaffold command
- include production-build verification steps and the next-intl App Router reference

Partial progress on #270 (one extension README; more welcome in follow-ups).

## Validation

- `npx --yes prettier@3.8.1 --check extensions/nextjs-i18n/README.md`
- parsed `templates.json` and `extensions/nextjs-i18n/package.json` with `python3 -m json.tool`
- verified each documented generated path exists