### PR TITLE
docs(nextjs-tailwindcss): add maintainer README

### DIFF
--- a/extensions/nextjs-tailwindcss/README.md
+++ b/extensions/nextjs-tailwindcss/README.md
@@ -1,0 +1,31 @@
+# Tailwind CSS for Next.js
+
+Adds Tailwind CSS v4 to a Next.js project with PostCSS configuration, utility-first styling, class-based dark mode, and starter theme variables.
+
+## Compatibility
+
+This extension is compatible with templates whose type is `nextjs`.
+
+## Apply
+
+```sh
+npx create-awesome-node-app my-app --template nextjs-starter --addons nextjs-tailwindcss
+```
+
+## What it adds
+
+- `postcss.config.mjs` - configures `@tailwindcss/postcss` and `autoprefixer`
+- `tailwind.config.ts` - configures source-file scanning and class-based dark mode
+- `src/app/globals.css` - imports Tailwind CSS and adds light and dark theme variables
+- `tailwindcss` and `@tailwindcss/postcss` - Tailwind CSS dependencies
+- `postcss` and `autoprefixer` - PostCSS development dependencies
+
+## Verify
+
+After scaffolding the app, install dependencies and run a production build:
+
+```sh
+cd my-app
+npm install
+npm run build
+```


### PR DESCRIPTION
## Summary

- Adds a maintainer README for the `nextjs-tailwindcss` extension
- Documents Next.js compatibility and the addon apply command
- Explains the files and dependencies added by the extension
- Includes production build verification steps

## Validation

- Ran `node scripts/validate-templates.js`
- Validation passed with existing unrelated warnings

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for configuring Tailwind CSS v4 in Next.js templates.
  * Included setup instructions, supported templates, added files and packages, and build verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->