### PR TITLE
fix(ci): respect packageManager field when running scaffold checks

### DIFF
--- a/.github/workflows/ci-templates.yml
+++ b/.github/workflows/ci-templates.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Enable corepack (for pnpm/yarn/bun templates)
+        run: corepack enable
+
       - name: Scaffold check (template alone)
         env:
           NODE_OPTIONS: --max-old-space-size=8192

--- a/scripts/ci/run-scaffold-check.js
+++ b/scripts/ci/run-scaffold-check.js
@@ -144,6 +144,23 @@ function hasScript(projectRoot, script) {
   return Boolean(pkg.scripts && pkg.scripts[script]);
 }
 
+function resolvePackageManager(projectRoot) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
+  if (!pkg.packageManager) return 'npm';
+  const [name] = pkg.packageManager.split('@');
+  return ['pnpm', 'yarn', 'bun'].includes(name) ? name : 'npm';
+}
+
+function ensurePackageManager(pm) {
+  if (pm === 'npm') return;
+  console.log(`\n▶ [setup-pm] enabling ${pm} via corepack`);
+  const result = spawnSync('corepack', ['enable', pm], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.warn(`⚠ [setup-pm] corepack failed, falling back to npm install -g ${pm}`);
+    spawnSync('npm', ['install', '-g', pm], { stdio: 'inherit', shell: true });
+  }
+}
+
 function main() {
   const args = parseArgs(process.argv);
   if (!args.templateUrl) {
@@ -188,11 +205,14 @@ function main() {
 
   assertNonEmptyProject(projectRoot);
 
-  run('install', 'npm', ['install'], { cwd: projectRoot });
+  const pm = resolvePackageManager(projectRoot);
+  ensurePackageManager(pm);
+
+  run('install', pm, ['install'], { cwd: projectRoot });
 
   if (hasScript(projectRoot, 'format')) {
-    console.log(`\n▶ [format] npm run format --if-present (soft)`);
-    const formatResult = spawnSync('npm', ['run', 'format', '--if-present'], {
+    console.log(`\n▶ [format] ${pm} run format (soft)`);
+    const formatResult = spawnSync(pm, ['run', 'format'], {
       cwd: projectRoot,
       stdio: 'inherit',
       env: { ...process.env, CI: 'true', FORCE_COLOR: '0' },
@@ -205,14 +225,14 @@ function main() {
   }
 
   if (hasScript(projectRoot, 'type-check')) {
-    run('type-check', 'npm', ['run', 'type-check'], { cwd: projectRoot });
+    run('type-check', pm, ['run', 'type-check'], { cwd: projectRoot });
   } else {
     console.log('ℹ [type-check] skipped (script not present)');
   }
 
   if (!args.skipBuild) {
     if (hasScript(projectRoot, 'build')) {
-      run('build', 'npm', ['run', 'build'], { cwd: projectRoot });
+      run('build', pm, ['run', 'build'], { cwd: projectRoot });
     } else {
       console.log('ℹ [build] skipped (script not present)');
     }
@@ -220,7 +240,7 @@ function main() {
 
   if (!args.skipTest) {
     if (hasScript(projectRoot, 'test')) {
-      run('test', 'npm', ['test'], { cwd: projectRoot });
+      run('test', pm, ['run', 'test'], { cwd: projectRoot });
     } else {
       console.log('ℹ [test] skipped (script not present)');
     }


### PR DESCRIPTION
## Problem

The `nextjs-saas-ai-starter` L1 CI job was failing with an npm ERESOLVE error:

```
npm error Found: valibot@0.39.0
npm error Could not resolve dependency:
npm error peerOptional valibot@"^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc" from @hookform/resolvers@5.5.3
```

Root cause: `run-scaffold-check.js` hardcoded `npm install` for all templates. But `nextjs-saas-ai-starter` declares `"packageManager": "pnpm@10.28.1"` — when npm resolves the dep tree it hits a transitive peer conflict (`@hookform/resolvers@5.5.3` → `@typeschema/valibot@0.14.0` → `valibot@0.39.0` vs the direct peer requirement `valibot@^1.0.0`). pnpm handles this without conflict.

## Fix

- **`scripts/ci/run-scaffold-check.js`**: adds `resolvePackageManager` (reads `packageManager` from the scaffolded `package.json`) and `ensurePackageManager` (enables via corepack, falls back to `npm install -g`). All install and script-run calls now use the detected manager.
- **`.github/workflows/ci-templates.yml`**: adds `corepack enable` before the scaffold check step so pnpm/yarn/bun are available on the runner.

## Test plan

- [ ] `nextjs-saas-ai-starter` L1 job passes (pnpm install used)
- [ ] All other L1 jobs pass unchanged (npm still used for templates without `packageManager`)
- [ ] `turborepo-starter` unaffected (`"packageManager": "npm@10.9.0"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved scaffold validation to detect and use the package manager declared by each project.
  * Added support for enabling package managers through Corepack, with a fallback installation method when needed.
  * Updated dependency installation and quality checks to run consistently with the selected package manager.
  * Preserved existing options for skipping builds or tests and handling formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->