### PR TITLE
feat: add nextjs-authkit extension (WorkOS AuthKit hosted auth UI)

### DIFF
--- a/extensions/nextjs-authkit/.env.example.append
+++ b/extensions/nextjs-authkit/.env.example.append
@@ -1,0 +1,5 @@
+# WorkOS AuthKit
+WORKOS_API_KEY=sk_your_api_key
+WORKOS_CLIENT_ID=client_your_client_id
+WORKOS_COOKIE_PASSWORD=<generate 32+ char secret>
+NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback

--- a/extensions/nextjs-authkit/.env.example.append
+++ b/extensions/nextjs-authkit/.env.example.append
@@ -1,5 +1,5 @@
 # WorkOS AuthKit
 WORKOS_API_KEY=sk_your_api_key
 WORKOS_CLIENT_ID=client_your_client_id
-WORKOS_COOKIE_PASSWORD=<generate 32+ char secret>
+WORKOS_COOKIE_PASSWORD="<replace-with-a-randomly-generated-secret-of-32+-characters>"
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback

--- a/extensions/nextjs-authkit/README.md
+++ b/extensions/nextjs-authkit/README.md
@@ -1,0 +1,145 @@
+# WorkOS AuthKit for Next.js
+
+Adds [WorkOS AuthKit](https://workos.com/docs/authkit) to your Next.js project —
+a fully hosted authentication UI with sign-in, sign-up, MFA, password reset,
+and enterprise SSO, with no auth screens for you to build or maintain.
+
+## AuthKit vs raw SSO: when to use which
+
+- **`nextjs-authkit`** (this extension) — you want a complete, hosted auth
+  experience out of the box: sign-in/sign-up pages, password reset, MFA, and
+  session management, all handled by WorkOS. Best default choice for most
+  apps, including B2C.
+- **`nextjs-workos`** — you only need the raw SSO connection (e.g. enterprise
+  customers signing in via their own IdP) and want to build your own sign-in
+  UI around it. More control, more work.
+
+These two extensions are **incompatible** — install only one.
+
+## Setup
+
+### 1. WorkOS dashboard setup
+
+1. Create a free account at [dashboard.workos.com](https://dashboard.workos.com).
+2. Grab your **API key** and **Client ID** from the dashboard home screen.
+3. Under **Redirects**, set:
+   - **Redirect URI**: `http://localhost:3000/callback` for local dev
+   - **Sign-in endpoint**: `http://localhost:3000/sign-in`
+   - **Logout URI**: wherever you want users sent after sign-out
+4. (Optional) Configure MFA, password policy, and SSO connections under
+   **Authentication** and **Organizations**.
+
+### 2. Environment configuration
+
+Copy the appended variables from `.env.example` into `.env.local` and fill them in:
+
+```
+WORKOS_API_KEY=sk_your_api_key
+WORKOS_CLIENT_ID=client_your_client_id
+WORKOS_COOKIE_PASSWORD=<generate 32+ char secret>
+NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
+```
+
+Generate a cookie password (must be 32+ characters) with:
+
+```bash
+openssl rand -base64 24
+```
+
+### 3. Callback and sign-in routes
+
+This extension adds two route handlers:
+
+- `app/callback/route.ts` — exchanges the WorkOS redirect code for a session.
+  Must be reachable at the exact path set as your dashboard's **Redirect URI**.
+- `app/sign-in/route.ts` — the entry point that starts the AuthKit flow. Must
+  match your dashboard's **Sign-in endpoint**. Without this, WorkOS-initiated
+  flows like dashboard impersonation will fail.
+
+### 4. proxy.ts / middleware integration
+
+This extension appends an AuthKit check into `middleware-handlers.ts`, the
+project's composable middleware system, using AuthKit's `authkit()` +
+`handleAuthkitHeaders()` helpers. This works the same way whether your
+project uses `proxy.ts` (Next.js 16+) or `middleware.ts` (Next.js ≤15) —
+only the entry file name differs, not the handler logic.
+
+### 5. Wrap your layout in `AuthKitProvider`
+
+```tsx
+import { AuthKitProvider } from '@workos-inc/authkit-nextjs/components';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthKitProvider>{children}</AuthKitProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+## Usage
+
+### `withAuth()` — server-side session
+
+Use in Server Components, Route Handlers, or Server Actions:
+
+```tsx
+import { getSignInUrl, getSignUpUrl, withAuth, signOut } from '@workos-inc/authkit-nextjs';
+
+export default async function HomePage() {
+  const { user } = await withAuth();
+
+  if (!user) {
+    const signInUrl = await getSignInUrl();
+    const signUpUrl = await getSignUpUrl();
+    return (
+      <>
+        <a href={signInUrl}>Log in</a>
+        <a href={signUpUrl}>Sign up</a>
+      </>
+    );
+  }
+
+  return (
+    <form action={async () => { 'use server'; await signOut(); }}>
+      <p>Welcome back{user.firstName && `, ${user.firstName}`}</p>
+      <button type="submit">Sign out</button>
+    </form>
+  );
+}
+```
+
+For pages where sign-in is mandatory, pass `{ ensureSignedIn: true }` to
+`withAuth()` — it will redirect unauthenticated users to AuthKit automatically.
+Don't wrap it in try/catch; Next.js redirects must happen outside one.
+
+### `useAuth()` — client-side session
+
+```tsx
+'use client';
+import { useAuth } from '@workos-inc/authkit-nextjs/components';
+
+export function UserBadge() {
+  const { user, loading } = useAuth();
+  if (loading) return null;
+  return <span>{user?.email}</span>;
+}
+```
+
+### Organization-to-tenant mapping
+
+For multi-tenant apps, each WorkOS `Organization` maps to a tenant in your
+app. The session's `organizationId` (available via `withAuth()`) is the key
+to use when scoping data per tenant — treat it the same way you'd treat a
+`tenantId` foreign key elsewhere in your schema. `refreshSession` /
+`refreshAuth` also accept an `organizationId` to switch a session between
+organizations.
+
+## References
+
+- [AuthKit Next.js docs](https://workos.com/docs/authkit/nextjs)
+- [authkit-nextjs GitHub repo & full README](https://github.com/workos/authkit-nextjs)
+- [WorkOS dashboard](https://dashboard.workos.com)

--- a/extensions/nextjs-authkit/README.md
+++ b/extensions/nextjs-authkit/README.md
@@ -33,10 +33,10 @@ These two extensions are **incompatible** — install only one.
 
 Copy the appended variables from `.env.example` into `.env.local` and fill them in:
 
-```
+```dotenv
 WORKOS_API_KEY=sk_your_api_key
 WORKOS_CLIENT_ID=client_your_client_id
-WORKOS_COOKIE_PASSWORD=<generate 32+ char secret>
+WORKOS_COOKIE_PASSWORD="<replace-with-a-randomly-generated-secret-of-32+-characters>"
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
 ```
 

--- a/extensions/nextjs-authkit/[src]/app/callback/route.ts
+++ b/extensions/nextjs-authkit/[src]/app/callback/route.ts
@@ -1,0 +1,8 @@
+import { handleAuth } from '@workos-inc/authkit-nextjs';
+
+// Handles the redirect back from WorkOS after a user signs in.
+// Must match NEXT_PUBLIC_WORKOS_REDIRECT_URI and the redirect URI
+// configured in the WorkOS dashboard (Redirects section).
+export const GET = handleAuth({
+  returnPathname: '/',
+});

--- a/extensions/nextjs-authkit/[src]/app/sign-in/route.ts
+++ b/extensions/nextjs-authkit/[src]/app/sign-in/route.ts
@@ -1,0 +1,9 @@
+import { getSignInUrl } from '@workos-inc/authkit-nextjs';
+import { redirect } from 'next/navigation';
+
+// Configure this route as the "Sign-in endpoint" in the WorkOS dashboard
+// (Redirects section). Required for dashboard-initiated impersonation to work.
+export const GET = async () => {
+  const signInUrl = await getSignInUrl();
+  return redirect(signInUrl);
+};

--- a/extensions/nextjs-authkit/[src]/middleware-handlers.ts.append.template
+++ b/extensions/nextjs-authkit/[src]/middleware-handlers.ts.append.template
@@ -1,0 +1,23 @@
+
+import { authkit, handleAuthkitHeaders } from '@workos-inc/authkit-nextjs';
+
+middlewareHandlers.push(async (request) => {
+  const { session, headers, authorizationUrl } = await authkit(request);
+  const { pathname } = request.nextUrl;
+
+  // Customize which paths require a signed-in session.
+  // Everything except "/" requires auth by default — adjust to your app's needs.
+  if (pathname !== '/' && !session.user && authorizationUrl) {
+    return {
+      response: handleAuthkitHeaders(request, headers, { redirect: authorizationUrl }),
+      priority: 10,
+    };
+  }
+
+  // Always forward AuthKit's headers, even on public routes —
+  // withAuth() in your pages depends on this running first.
+  return {
+    response: handleAuthkitHeaders(request, headers),
+    priority: 0,
+  };
+});

--- a/extensions/nextjs-authkit/[src]/middleware-handlers.ts.append.template
+++ b/extensions/nextjs-authkit/[src]/middleware-handlers.ts.append.template
@@ -7,7 +7,9 @@ middlewareHandlers.push(async (request) => {
 
   // Customize which paths require a signed-in session.
   // Everything except "/" requires auth by default — adjust to your app's needs.
-  if (pathname !== '/' && !session.user && authorizationUrl) {
+  const isPublicPath =
+    pathname === '/' || pathname === '/callback' || pathname === '/sign-in';
+  if (!isPublicPath && !session.user && authorizationUrl) {
     return {
       response: handleAuthkitHeaders(request, headers, { redirect: authorizationUrl }),
       priority: 10,

--- a/extensions/nextjs-authkit/package.json
+++ b/extensions/nextjs-authkit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nextjs-authkit-extension",
+  "dependencies": {
+    "@workos-inc/authkit-nextjs": "^4.3.0",
+    "@workos-inc/node": "^10.8.0"
+  },
+  "devDependencies": {}
+}

--- a/templates.json
+++ b/templates.json
@@ -930,7 +930,23 @@
         "Authentication",
         "OAuth",
         "Session"
-      ]
+      ],
+      "incompatibleWith": ["nextjs-authkit"]
+    },{
+      "name": "WorkOS AuthKit",
+      "slug": "nextjs-authkit",
+      "description": "Hosted authentication platform with pre-built UI, SSO, MFA, and password reset via WorkOS AuthKit.",
+      "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/nextjs-authkit",
+      "type": "nextjs",
+      "category": "Auth",
+      "labels": [
+        "sso",
+        "workos",
+        "authkit",
+        "enterprise",
+        "auth"
+      ],
+      "incompatibleWith": ["nextjs-auth"]
     },
     {
       "name": "t3-env for Next.js",


### PR DESCRIPTION
Closes #283

Adds a new `nextjs-authkit` extension providing hosted authentication via WorkOS AuthKit — sign-in, sign-up, MFA, password reset, and enterprise SSO, matching the file structure and conventions of the existing `nextjs-auth` extension.

## What's included
- `package.json` — declares `@workos-inc/authkit-nextjs` and `@workos-inc/node` dependencies
- `.env.example.append` — required env vars
- `[src]/app/callback/route.ts` — WorkOS redirect callback handler
- `[src]/app/sign-in/route.ts` — sign-in endpoint (required for dashboard-initiated impersonation)
- `[src]/middleware-handlers.ts.append.template` — composable middleware integration using `authkit()` + `handleAuthkitHeaders()`
- `README.md` — full setup guide
- `templates.json` registry entry, marked `incompatibleWith: nextjs-auth` (and vice versa)

## Testing done
- `node scripts/validate-templates.js` passes with no new warnings
- Scaffolded via `scripts/ci/run-scaffold-check.js` against `nextjs-starter` — install, type-check, and build all pass
- Manually tested the full sign-in flow end-to-end against a live WorkOS staging project: hit `/sign-in`, completed sign-in on WorkOS's hosted page, redirected back through `/callback`, landed authenticated on the home page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a WorkOS AuthKit integration for Next.js applications, including sign-in and callback routes with automatic redirect flow.
  - Added middleware support to protect routes and forward authenticated session details.
  - Added an AuthKit configuration template with environment variable guidance (including a redirect URI example) and expanded setup documentation.
  - Added compatibility rules to prevent simultaneous use with the Auth.js v5 for Next.js template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->