### PR TITLE
fix(security): resolve all Dependabot alerts in danger tooling

### DIFF
--- a/templates/nextjs-saas-ai-starter/tools/danger/package-lock.json
+++ b/templates/nextjs-saas-ai-starter/tools/danger/package-lock.json
@@ -1054,11 +1054,12 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1317,11 +1318,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/universal-user-agent": {
@@ -1746,7 +1748,7 @@
         "regenerator-runtime": "^0.13.9",
         "require-from-string": "^2.0.2",
         "supports-hyperlinks": "^4.3.0",
-        "undici": "6.21.1"
+        "undici": ">=6.27.0"
       }
     },
     "debug": {
@@ -1964,7 +1966,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "picomatch": ">=2.3.2"
       }
     },
     "minimist": {
@@ -2019,9 +2021,9 @@
       }
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
     },
     "pinpoint": {
       "version": "1.1.0",
@@ -2186,9 +2188,9 @@
       }
     },
     "undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="
     },
     "universal-user-agent": {
       "version": "6.0.1",

--- a/templates/nextjs-saas-ai-starter/tools/danger/package.json
+++ b/templates/nextjs-saas-ai-starter/tools/danger/package.json
@@ -21,5 +21,9 @@
   },
   "devDependencies": {
     "typescript": "^7.0.2"
+  },
+  "overrides": {
+    "undici": ">=6.27.0",
+    "picomatch": ">=2.3.2"
   }
 }


### PR DESCRIPTION
## Summary

Resolves all open Dependabot security alerts in `templates/nextjs-saas-ai-starter/tools/danger/`.

### Root cause

`danger@13.0.10` transitively depends on:
- `undici@6.21.1` — affected by 11 CVEs (high/medium/low)
- `picomatch@2.3.1` — affected by 2 CVEs (high/medium)

There is no newer `danger` release that bundles safe versions, so the fix uses npm `overrides` to force the resolved versions upward without downgrading `danger` itself.

### Changes

| Package | Before | After | Fixes |
|---------|--------|-------|-------|
| `undici` | 6.21.1 | 8.9.0 | 11 CVEs |
| `picomatch` | 2.3.1 | 4.0.5 | 2 CVEs |

`npm audit` reports **0 vulnerabilities** after the change.

## Test plan

- [ ] CI passes (danger tooling is not exercised in L0–L3 scaffolding CI, only in PR automation)
- [ ] `npm audit` in `templates/nextjs-saas-ai-starter/tools/danger/` → 0 vulnerabilities