### PR TITLE
docs: add READMEs for templates missing them

### DIFF
--- a/templates/astro-starter/README.md
+++ b/templates/astro-starter/README.md
@@ -1,27 +1,61 @@
 # Astro Starter
 
-Astro static site with TypeScript and an island-friendly structure. Ideal for
-docs, marketing, and content sites that ship fast static HTML.
+> Static-first Astro site with TypeScript, content collections, and island architecture — ideal for docs, marketing, and content sites that ship fast HTML.
+
+[![Astro](https://img.shields.io/badge/Astro-7-FF5D01?logo=astro&logoColor=white)](https://astro.build) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- Astro
-- TypeScript
-- ESLint and Prettier
-- Node.js pinned via `.node-version`
+| Layer | Tool |
+|-------|------|
+| Framework | Astro 7 (static + islands) |
+| Language | TypeScript (strict) |
+| Content | Content Collections (`src/content/`) |
+| Lint/Format | ESLint (`eslint-plugin-astro`) + Prettier (`prettier-plugin-astro`) |
+| Runtime | Node 22.14.0 (`.node-version` + `engines`) |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template astro-starter
+# or with pnpm/yarn/bun — the CLI adapts installCommand/runCommand
 ```
+
+Generated project uses `README.md.template` → `README.md` with your `projectName`.
 
 ## Key features
 
-- File-based routing and content collections
-- Shared layouts and SEO metadata
-- Strict TypeScript with `astro check`
-- Static-first output with room for UI islands when needed
+- File-based routing (`src/pages/`) + content collections (`src/content/blog` → `/blog`)
+- Shared `BaseLayout` + `BaseHead` for SEO (title, description, OG)
+- `astro check` strict TypeScript
+- Static output by default, opt-in islands (`npx astro add react`)
+- No heavy test/husky preset — add when you need it
 
-See [`docs/`](./docs) for project structure, styling, configuration, and state
-management guidance.
+## Project structure
+
+```
+src/
+  pages/        # Astro pages + blog routes
+  layouts/      # BaseLayout.astro
+  components/   # BaseHead.astro
+  content/      # Collections config + markdown
+  styles/       # blog.css, cna-landing.css
+docs/
+  PROJECT_STRUCTURE.md  # Full layout
+  COMPONENTS_AND_STYLING.md
+  PROJECT_CONFIGURATION.md
+```
+
+See [`docs/`](./template/docs) for full guides (structure, styling, config, state).
+
+## Scripts (generated project)
+
+| `npm run <script>` | Description |
+|--------------------|-------------|
+| `dev` | `astro dev` — dev server http://localhost:4321 |
+| `build` | `astro build` → `dist/` |
+| `preview` | Preview production build |
+
+---
+
+*Thanks to @slegarraga for adding the catalog READMEs — improved with stack table and quickstart.*

--- a/templates/astro-starter/README.md
+++ b/templates/astro-starter/README.md
@@ -1,0 +1,27 @@
+# Astro Starter
+
+Astro static site with TypeScript and an island-friendly structure. Ideal for
+docs, marketing, and content sites that ship fast static HTML.
+
+## Tech stack
+
+- Astro
+- TypeScript
+- ESLint and Prettier
+- Node.js pinned via `.node-version`
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template astro-starter
+```
+
+## Key features
+
+- File-based routing and content collections
+- Shared layouts and SEO metadata
+- Strict TypeScript with `astro check`
+- Static-first output with room for UI islands when needed
+
+See [`docs/`](./docs) for project structure, styling, configuration, and state
+management guidance.

--- a/templates/hono-starter/README.md
+++ b/templates/hono-starter/README.md
@@ -1,15 +1,19 @@
 # Hono Starter
 
-Minimal Hono API in TypeScript. Use it for edge, serverless, or small HTTP
-services where a larger framework would be heavier than needed.
+> Minimal Hono API in TypeScript — edge/serverless-friendly, Zod-validated, with Vitest smoke tests. Reach for it when Express/Nest is heavier than you need.
+
+[![Hono](https://img.shields.io/badge/Hono-4-E36002?logo=hono&logoColor=white)](https://hono.dev) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- Hono
-- TypeScript
-- Zod
-- Vitest
-- ESLint and Prettier
+| Layer | Tool |
+|-------|------|
+| Framework | Hono 4 (Node, edge, serverless) |
+| Language | TypeScript (strict) |
+| Validation | Zod (env + request bodies) |
+| Test | Vitest |
+| Lint/Format | ESLint + Prettier |
+| Runtime | Node 22 + `.node-version` |
 
 ## Scaffold
 
@@ -19,10 +23,22 @@ npx create-awesome-node-app --template hono-starter
 
 ## Key features
 
-- Modular route organization
-- Zod-validated environment and request bodies
-- JSON error handling
-- Vitest smoke tests
-- `GET /` and `GET /health` endpoints included
+- Modular routes (`src/routes/` → `GET /`, `GET /health`, `POST /echo`)
+- Zod env + request validation, JSON error handling (`src/middleware/error-handler.ts`)
+- `GET /health` ready for probes, `POST /echo` validates `{ message }`
+- `_module-template/` to copy-paste new modules
+- `vitest` smoke tests (`tests/app.test.ts`) + `cna.config.json` with no prompts
 
-See [`docs/`](./docs) for project structure, API, configuration, and testing guidance.
+## Docs
+
+- [`docs/README.md`](./template/docs/README.md) — overview
+- [`docs/PROJECT_STRUCTURE.md`](./template/docs/PROJECT_STRUCTURE.md)
+- [`docs/API.md`](./template/docs/API.md) — endpoints
+- [`docs/CONFIGURATION.md`](./template/docs/CONFIGURATION.md)
+- [`docs/TESTING.md`](./template/docs/TESTING.md)
+
+Compatible extensions: `github-setup`, `husky-lint-staged`, `development-container`.
+
+---
+
+*Thanks to @slegarraga for the initial catalog READMEs — enhanced with stack table and endpoint list.*

--- a/templates/hono-starter/README.md
+++ b/templates/hono-starter/README.md
@@ -1,0 +1,28 @@
+# Hono Starter
+
+Minimal Hono API in TypeScript. Use it for edge, serverless, or small HTTP
+services where a larger framework would be heavier than needed.
+
+## Tech stack
+
+- Hono
+- TypeScript
+- Zod
+- Vitest
+- ESLint and Prettier
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template hono-starter
+```
+
+## Key features
+
+- Modular route organization
+- Zod-validated environment and request bodies
+- JSON error handling
+- Vitest smoke tests
+- `GET /` and `GET /health` endpoints included
+
+See [`docs/`](./docs) for project structure, API, configuration, and testing guidance.

--- a/templates/nestjs-starter/README.md
+++ b/templates/nestjs-starter/README.md
@@ -1,28 +1,50 @@
 # NestJS Boilerplate
 
-Modular NestJS API with TypeScript, ESLint, and Prettier. Reach for it when you
-want controllers, providers, and clear module boundaries in an HTTP service.
+> Modular NestJS API with TypeScript, OpenAPI/Swagger, Zod env validation, and Docker — clear module boundaries for HTTP services.
+
+[![NestJS](https://img.shields.io/badge/NestJS-11-E0234E?logo=nestjs&logoColor=white)](https://nestjs.com) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- NestJS
-- TypeScript
-- Jest
-- Zod and `@nestjs/config`
-- OpenAPI / Swagger
+| Layer | Tool |
+|-------|------|
+| Framework | NestJS 11 (controllers, providers, modules) |
+| Language | TypeScript |
+| Validation | Zod + `@nestjs/config` |
+| Docs | OpenAPI/Swagger (`/docs`) |
+| Test | Jest + e2e (`test/`) |
+| Tooling | ESLint, Prettier, Docker, Compose |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template nestjs-boilerplate
+# directory is templates/nestjs-starter — public slug is nestjs-boilerplate
 ```
 
 ## Key features
 
-- Module-based NestJS layout
-- OpenAPI documentation at `/docs`
-- Zod-validated environment variables
-- Global exception filter and request logging interceptor
-- Docker Compose workflow
+- Module layout (`src/app.module.ts`, `src/health/`, `src/common/{filters,interceptors,dto}`)
+- Swagger UI at `http://localhost:3000/docs` (`/` + `/health` documented)
+- `env.schema.ts` + `env.validation.ts` (Zod via `@nestjs/config`)
+- Global `HttpExceptionFilter` + `LoggingInterceptor`
+- `Dockerfile` + `compose.yml`/`compose.prod.yml` + `docker/docker-compose.sh`
+- `.node-version` pinned, `.env.example` provided
 
-See [`docs/`](./docs) for project structure, configuration, testing, and API guidance.
+## Docs
+
+See [`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `CONFIGURATION.md`, `API.md`, `TESTING.md`.
+
+## Quickstart
+
+```bash
+fnm use
+npm install
+npm run dev        # http://localhost:3000
+# or
+npm run compose:up # Docker
+```
+
+---
+
+*Thanks to @slegarraga — improved with correct public slug and Docker notes.*

--- a/templates/nestjs-starter/README.md
+++ b/templates/nestjs-starter/README.md
@@ -1,0 +1,28 @@
+# NestJS Boilerplate
+
+Modular NestJS API with TypeScript, ESLint, and Prettier. Reach for it when you
+want controllers, providers, and clear module boundaries in an HTTP service.
+
+## Tech stack
+
+- NestJS
+- TypeScript
+- Jest
+- Zod and `@nestjs/config`
+- OpenAPI / Swagger
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template nestjs-boilerplate
+```
+
+## Key features
+
+- Module-based NestJS layout
+- OpenAPI documentation at `/docs`
+- Zod-validated environment variables
+- Global exception filter and request logging interceptor
+- Docker Compose workflow
+
+See [`docs/`](./docs) for project structure, configuration, testing, and API guidance.

--- a/templates/nextjs-starter/README.md
+++ b/templates/nextjs-starter/README.md
@@ -1,0 +1,25 @@
+# Next.js Starter
+
+Next.js App Router starter with TypeScript and a feature-based layout. Use it for full-stack React apps that need server rendering, routing, and a scalable source structure.
+
+## Tech stack
+
+- Next.js App Router
+- React
+- TypeScript
+- ESLint, Prettier, and Markdown linting
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template nextjs-starter
+```
+
+## Key features
+
+- Feature-based architecture
+- Encapsulated modules with clear boundaries
+- React Server Components
+- App Router conventions and middleware examples
+
+See [`docs/`](./docs) for project configuration, components, performance, and state management guidance.

--- a/templates/nextjs-starter/README.md
+++ b/templates/nextjs-starter/README.md
@@ -1,13 +1,18 @@
 # Next.js Starter
 
-Next.js App Router starter with TypeScript and a feature-based layout. Use it for full-stack React apps that need server rendering, routing, and a scalable source structure.
+> Next.js App Router + React + TypeScript with feature-based architecture — full-stack React with server components, nested routes, and clear module boundaries.
+
+[![Next.js](https://img.shields.io/badge/Next.js-15-black?logo=next.js)](https://nextjs.org) [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- Next.js App Router
-- React
-- TypeScript
-- ESLint, Prettier, and Markdown linting
+| Layer | Tool |
+|-------|------|
+| Framework | Next.js 15 (App Router) |
+| Language | TypeScript (strict) |
+| UI | React 19 + Server Components |
+| Lint/Format | ESLint + Prettier + markdownlint |
+| Runtime | Node 22 |
 
 ## Scaffold
 
@@ -17,9 +22,18 @@ npx create-awesome-node-app --template nextjs-starter
 
 ## Key features
 
-- Feature-based architecture
-- Encapsulated modules with clear boundaries
-- React Server Components
-- App Router conventions and middleware examples
+- Feature-based architecture (`[src]/features/auth` → `components/`, `hooks/`, `services/`)
+- Encapsulated feature modules + domain-driven design
+- App Router conventions (`[src]/app/(auth)/login/page.tsx` example)
+- `instrumentation.ts` + `middleware.ts` templates
+- `cna.config.json` → `srcDir` prompt (default `src/`)
 
-See [`docs/`](./docs) for project configuration, components, performance, and state management guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `COMPONENTS_AND_STYLING.md`, `STATE_MANAGEMENT.md`, `PROJECT_CONFIGURATION.md`.
+
+Includes example auth feature (`features/auth`) to copy for new domains.
+
+---
+
+*Thanks to @slegarraga for the catalog READMEs — enhanced with App Router details.*

--- a/templates/react-vite-starter/README.md
+++ b/templates/react-vite-starter/README.md
@@ -1,27 +1,38 @@
 # React Vite Boilerplate
 
-React SPA on Vite with React Router and TypeScript. Choose it for client-only apps where instant HMR and a lean build matter.
+> React SPA on Vite with React Router, TypeScript, and feature-based architecture — instant HMR for client-only apps where build speed matters.
+
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev) [![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite)](https://vitejs.dev) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- React
-- Vite
-- React Router
-- TypeScript
-- ESLint, Prettier, and Markdown linting
+| Layer | Tool |
+|-------|------|
+| Framework | React 19 + React Router (SPA) |
+| Bundler | Vite 6 (HMR) |
+| Language | TypeScript |
+| Lint/Format | ESLint + Prettier + markdownlint |
+| Test | Vitest (via extension) |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template react-vite-boilerplate
+# directory is templates/react-vite-starter — public slug is react-vite-boilerplate
 ```
 
 ## Key features
 
-- Instant Vite HMR
-- Feature-based architecture
-- Encapsulated feature modules
-- Domain-driven design guidance
-- TypeScript type safety
+- Instant Vite HMR + `index.html.template` with `<%= projectName %>`
+- Feature-based modules (`[src]/features/_feature-template_/`)
+- `AGENTS.md.template` + `docs/` guides (structure, styling, state)
+- `vite.config.ts.template`, `tsconfig.json.template` with path aliases
+- `cna.config.json` → `srcDir` prompt
 
-See [`docs/`](./docs) for project structure, configuration, components, performance, and state management guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `COMPONENTS_AND_STYLING.md`, `PERFORMANCE.md`.
+
+---
+
+*Thanks to @slegarraga — corrected public slug and added Vite/HMR notes.*

--- a/templates/react-vite-starter/README.md
+++ b/templates/react-vite-starter/README.md
@@ -1,0 +1,27 @@
+# React Vite Boilerplate
+
+React SPA on Vite with React Router and TypeScript. Choose it for client-only apps where instant HMR and a lean build matter.
+
+## Tech stack
+
+- React
+- Vite
+- React Router
+- TypeScript
+- ESLint, Prettier, and Markdown linting
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template react-vite-boilerplate
+```
+
+## Key features
+
+- Instant Vite HMR
+- Feature-based architecture
+- Encapsulated feature modules
+- Domain-driven design guidance
+- TypeScript type safety
+
+See [`docs/`](./docs) for project structure, configuration, components, performance, and state management guidance.

--- a/templates/remix-starter/README.md
+++ b/templates/remix-starter/README.md
@@ -1,15 +1,17 @@
 # Remix Starter
 
-React Router v7 with file-based routes, loaders/actions, and TypeScript. Pick it
-when you want SSR and nested data routes in a full-stack React app.
+> React Router v7 with file-based routes, loaders/actions, and TypeScript — SSR and nested data routes for full-stack React.
+
+[![React Router](https://img.shields.io/badge/React_Router-7-CA4245?logo=reactrouter&logoColor=white)](https://reactrouter.com) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- React Router v7
-- React
-- TypeScript
-- Vite
-- ESLint and Prettier
+| Layer | Tool |
+|-------|------|
+| Framework | React Router v7 (file-based routes) |
+| Language | TypeScript (strict) |
+| Bundler | Vite 6 |
+| Lint/Format | ESLint + Prettier |
 
 ## Scaffold
 
@@ -19,10 +21,16 @@ npx create-awesome-node-app --template remix-starter
 
 ## Key features
 
-- File-based routes
-- Loaders and actions
-- Nested routes and data patterns
-- Production build and dev server scripts
+- File-based routes (`app/routes/_index.tsx.template`)
+- Loaders + actions (contact demo with in-memory store)
+- Nested routes and `ErrorBoundary` at root
+- `vite.config.ts.template` + `react-router.config.ts.template`
+- `cna.config.json` → `srcDir` prompt
 
-See [`docs/`](./docs) for project structure, configuration, components, and
-state management guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `COMPONENTS_AND_STYLING.md`, `PROJECT_CONFIGURATION.md`. Demo routes: `/contact` (loader/action), root error boundary.
+
+---
+
+*Thanks to @slegarraga — enhanced with React Router v7 details.*

--- a/templates/remix-starter/README.md
+++ b/templates/remix-starter/README.md
@@ -1,0 +1,28 @@
+# Remix Starter
+
+React Router v7 with file-based routes, loaders/actions, and TypeScript. Pick it
+when you want SSR and nested data routes in a full-stack React app.
+
+## Tech stack
+
+- React Router v7
+- React
+- TypeScript
+- Vite
+- ESLint and Prettier
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template remix-starter
+```
+
+## Key features
+
+- File-based routes
+- Loaders and actions
+- Nested routes and data patterns
+- Production build and dev server scripts
+
+See [`docs/`](./docs) for project structure, configuration, components, and
+state management guidance.

--- a/templates/turborepo-starter/README.md
+++ b/templates/turborepo-starter/README.md
@@ -1,26 +1,39 @@
 # Turborepo Boilerplate
 
-Turborepo workspace with TypeScript, Changesets, and shared packages. Best when multiple apps share UI or config and you want a fast monorepo workflow.
+> Turborepo + pnpm workspaces with shared packages, Changesets, and React+Vite apps — fast monorepo for teams sharing UI/config.
+
+[![Turborepo](https://img.shields.io/badge/Turborepo-2-EF4444?logo=turborepo&logoColor=white)](https://turbo.build) [![pnpm](https://img.shields.io/badge/pnpm-10-F69220?logo=pnpm)](https://pnpm.io) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- Turborepo
-- TypeScript
-- Changesets
-- pnpm
-- ESLint and Prettier
+| Layer | Tool |
+|-------|------|
+| Monorepo | Turborepo 2 + pnpm workspaces |
+| Language | TypeScript |
+| Release | Changesets |
+| Lint/Format | ESLint + Prettier |
+| Apps | `apps/web` (Vite+React), `apps/playground` (Storybook) |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template turborepo-boilerplate
+# directory is templates/turborepo-starter — public slug is turborepo-boilerplate
 ```
+
+Requires `pnpm` — `pnpm-workspace.yaml.if-pnpm` is included.
 
 ## Key features
 
-- Workspace-based package organization
-- Shared packages and configuration
-- Changesets for release management
-- Task caching through Turborepo
+- `apps/web` consumes `packages/ui` (shared React), `apps/playground` for Storybook
+- `packages/*` + `apps/*` workspaces, `turbo run` task caching
+- Changesets for versioning (`npm run changeset`, `publish-packages`)
+- `cna.config.json` → `scope` + `projectName` (default `@app/` + `turbo-app`)
 
-See [`docs/`](./docs) for project structure and development workflow guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — monorepo structure, tasks, release workflow.
+
+---
+
+*Thanks to @slegarraga — corrected public slug and added pnpm note.*

--- a/templates/turborepo-starter/README.md
+++ b/templates/turborepo-starter/README.md
@@ -1,0 +1,26 @@
+# Turborepo Boilerplate
+
+Turborepo workspace with TypeScript, Changesets, and shared packages. Best when multiple apps share UI or config and you want a fast monorepo workflow.
+
+## Tech stack
+
+- Turborepo
+- TypeScript
+- Changesets
+- pnpm
+- ESLint and Prettier
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template turborepo-boilerplate
+```
+
+## Key features
+
+- Workspace-based package organization
+- Shared packages and configuration
+- Changesets for release management
+- Task caching through Turborepo
+
+See [`docs/`](./docs) for project structure and development workflow guidance.

--- a/templates/wdio-starter/README.md
+++ b/templates/wdio-starter/README.md
@@ -1,0 +1,29 @@
+# WebdriverIO Boilerplate
+
+WebdriverIO + TypeScript harness with a Selenoid-friendly setup. Scaffold this
+when the project is an acceptance-test suite rather than an application.
+
+## Tech stack
+
+- WebdriverIO
+- TypeScript
+- Mocha and Chai
+- Selenoid
+- Multiple reporters
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template webdriverio-boilerplate
+```
+
+## Key features
+
+- Cross-browser test execution
+- Parallel test runs
+- Containerized Selenoid support
+- Configurable reporters
+- Type-safe test code
+
+See [`docs/`](./docs) for project structure, configuration, test writing, and
+execution guidance.

--- a/templates/wdio-starter/README.md
+++ b/templates/wdio-starter/README.md
@@ -1,29 +1,41 @@
 # WebdriverIO Boilerplate
 
-WebdriverIO + TypeScript harness with a Selenoid-friendly setup. Scaffold this
-when the project is an acceptance-test suite rather than an application.
+> WebdriverIO + TypeScript + Selenoid harness for browser acceptance-test suites — cross-browser, parallel, containerized.
+
+[![WebdriverIO](https://img.shields.io/badge/WebdriverIO-8-EA5906?logo=webdriverio&logoColor=white)](https://webdriver.io) [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org)
 
 ## Tech stack
 
-- WebdriverIO
-- TypeScript
-- Mocha and Chai
-- Selenoid
-- Multiple reporters
+| Layer | Tool |
+|-------|------|
+| Runner | WebdriverIO 8 (Mocha + Chai) |
+| Language | TypeScript |
+| Grid | Selenoid (Docker) + `bin/selenoid` |
+| Reports | Multiple reporters + `allure` |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template webdriverio-boilerplate
+# directory is templates/wdio-starter — public slug is webdriverio-boilerplate
 ```
+
+*Note:* This template scaffolds a **test suite**, not an app — `test/` + `wdio.conf.js` are the product.
 
 ## Key features
 
-- Cross-browser test execution
-- Parallel test runs
-- Containerized Selenoid support
-- Configurable reporters
-- Type-safe test code
+- Cross-browser (`Chrome`, `Firefox`, `Safari`) + parallel execution
+- `config/` (capabilities) + `types/` helpers + `bin/selenoid` for grid
+- `wdio.conf.js` with `allure` + `spec` reporters, `maxInstances`
+- `.env.example` for `GRID_HOST` etc., `test/` structure for specs
+- `tsconfig.json` for type-safe specs
 
-See [`docs/`](./docs) for project structure, configuration, test writing, and
-execution guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `TEST_CONFIGURATION.md`, `WRITING_TESTS.md`, `RUNNING_TESTS.md`.
+
+Run: `npm test` (local) or `npm run test:remote` (Selenoid).
+
+---
+
+*Thanks to @slegarraga — corrected public slug and clarified test-suite purpose.*

--- a/templates/webextension-react-vite-starter/README.md
+++ b/templates/webextension-react-vite-starter/README.md
@@ -1,27 +1,40 @@
 # Web Extension React Vite Boilerplate
 
-React + Vite WebExtension with HMR and polyfills. Use it for Chrome/Firefox/Edge extensions that share a React UI across contexts.
+> React + Vite WebExtension with HMR, `webextension-polyfill`, and cross-browser `manifest.json` — Chrome/Firefox/Edge from one codebase.
+
+[![Vite](https://img.shields.io/badge/Vite-6-646CFF?logo=vite)](https://vitejs.dev) [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev) [![WebExtension](https://img.shields.io/badge/WebExtension-polyfill-FF7139?logo=firefox)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions)
 
 ## Tech stack
 
-- React
-- Vite
-- TypeScript
-- WebExtension APIs
-- Vitest
+| Layer | Tool |
+|-------|------|
+| Framework | React 19 + Vite 6 |
+| Extension | `webextension-polyfill` + `manifest.ts.template` (typed) |
+| Language | TypeScript |
+| Test | Vitest + Testing Library |
+| Tooling | `web-ext` (run in browsers) |
 
 ## Scaffold
 
 ```bash
 npx create-awesome-node-app --template web-extension-react-boilerplate
+# directory is templates/webextension-react-vite-starter — public slug is web-extension-react-boilerplate
 ```
 
 ## Key features
 
-- Instant Vite HMR
-- Communication between extension contexts
-- Dynamic `manifest.json` with type support
-- Cross-browser extension structure
-- Vitest setup and mocks
+- Instant HMR (`vite.config.ts.template` + `public/`) + `manifest.ts.template` → `manifest.json` with types
+- Shared `src/` islands: `popup/`, `options/`, `panel/`, `background/`, `content/`, `devtools/`, `shared/`
+- Message passing (`shared/messages.ts`) + `Browser` polyfill
+- `vitest.config.ts.template` + `vitest.setup.ts.template` with `jsdom`
+- `web-ext:chromium` / `web-ext:firefox` scripts
 
-See [`docs/`](./docs) for project structure, configuration, components, performance, and state management guidance.
+## Docs
+
+[`template/docs/`](./template/docs) — `PROJECT_STRUCTURE.md`, `COMPONENTS_AND_STYLING.md`, `PERFORMANCE.md`.
+
+Load: `npm run web-ext:chromium` or `web-ext:firefox` after `npm run dev`.
+
+---
+
+*Thanks to @slegarraga — corrected public slug and added HMR/manifest notes.*

--- a/templates/webextension-react-vite-starter/README.md
+++ b/templates/webextension-react-vite-starter/README.md
@@ -1,0 +1,27 @@
+# Web Extension React Vite Boilerplate
+
+React + Vite WebExtension with HMR and polyfills. Use it for Chrome/Firefox/Edge extensions that share a React UI across contexts.
+
+## Tech stack
+
+- React
+- Vite
+- TypeScript
+- WebExtension APIs
+- Vitest
+
+## Scaffold
+
+```bash
+npx create-awesome-node-app --template web-extension-react-boilerplate
+```
+
+## Key features
+
+- Instant Vite HMR
+- Communication between extension contexts
+- Dynamic `manifest.json` with type support
+- Cross-browser extension structure
+- Vitest setup and mocks
+
+See [`docs/`](./docs) for project structure, configuration, components, performance, and state management guidance.


### PR DESCRIPTION
Adds READMEs for the nine templates listed in the issue, each with a description, tech stack, scaffold command, key features, and a link to the existing docs.

Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README guides for Astro, Hono, NestJS, Next.js, React Vite, Remix, Turborepo, WebdriverIO, and WebExtension starter templates.
  * Documented each template’s technology stack, setup or scaffolding commands, key features, and links to additional guidance.
  * Included framework-specific details such as routing, endpoints, server components, testing capabilities, and build tooling where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->