### PR TITLE
fix(extensions): pin jsdom to 29.1.1 — v30 breaks vitest getComputedStyle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@prisma/client"
         update-types: ["version-update:semver-major"]
+      # jsdom 30 breaks @testing-library/dom getComputedStyle (font-sizes.js:116) — see #341
+      - dependency-name: jsdom
+        versions: [">=30"]
     groups:
       devDependencies:
         dependency-type: development

--- a/extensions/react-testing-library-with-vitest/package.json
+++ b/extensions/react-testing-library-with-vitest/package.json
@@ -5,7 +5,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
-    "jsdom": "^30.0.0",
+    "jsdom": "^29.1.1",
     "vitest": "^4.1.9"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

jsdom 30.0.0 regresses with `@testing-library/dom` `getComputedStyle` (`font-sizes.js:116 TypeError: object null is not iterable`) causing L2/L3 failures in https://github.com/Create-Node-App/cna-templates/actions/runs/30358315777 (see #341).

## Change

- Revert `extensions/react-testing-library-with-vitest/package.json` to `^29.1.1`
- Add dependabot ignore for `jsdom >=30` in `.github/dependabot.yml` (alongside existing prisma ignores)
- Mirrored decision in `knowledge/processes/create-node-app-maintenance.md` (workspace)

## Validation

Local `file://` scaffold (runbook §5.4) with `templates/react-vite-starter` + `react-testing-library-with-vitest`:

```bash
REPO=/abs/path/to/cna-templates
CI=true npx create-awesome-node-app@latest /tmp/scaffold-check-jsdom \
  --template "file://$REPO?subdir=templates/react-vite-starter" \
  --addons "file://$REPO?subdir=extensions/react-testing-library-with-vitest" --no-install
cd /tmp/scaffold-check-jsdom && npm install && npm run type-check && npm test
```

Result: `install 0 vuln, type-check ok, vitest 1 passed`.

## Risk

Low — docs-only dependency pin, prevents future Dependabot re-bumping to 30 until upstream fixes.

Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved testing environment stability by aligning the browser simulation tooling with the supported test setup.
  - Updated automated maintenance settings to prevent incompatible updates from being introduced automatically.
  - No user-facing features or application behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->