### PR TITLE
test: add react material-ui and hook-form profile

### DIFF
--- a/ci/profiles/react-material-ui-hook-form.json
+++ b/ci/profiles/react-material-ui-hook-form.json
@@ -1,0 +1,9 @@
+{
+  "id": "react-material-ui-hook-form",
+  "description": "React Vite app with Material UI components and React Hook Form",
+  "templateDir": "react-vite-starter",
+  "addons": [
+    "material-ui",
+    "react-hook-form"
+  ]
+}


### PR DESCRIPTION
Closes #275.

The smoke-test workflow referenced in the issue no longer exists; the repo now uses curated L3 profiles in `ci/profiles/*.json`. This adds `react-material-ui-hook-form.json` covering `react-vite-starter` + `material-ui` + `react-hook-form`, so the combo is scaffolded, installed, type-checked, built, and tested on every CI run.

Validated with `node scripts/ci/generate-matrix.js --layer validate-profiles` (8 profiles pass).