### PR TITLE
chore(deps): bump Next.js to 16.3.0 in nextjs-starter

### DIFF
--- a/templates/nextjs-starter/template/package.json
+++ b/templates/nextjs-starter/template/package.json
@@ -13,20 +13,20 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "^16.2.10",
+    "next": "^16.3.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "^16.2.10",
+    "@next/eslint-plugin-next": "^16.3.0",
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "autoprefixer": "^10.5.2",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^16.2.10",
+    "eslint-config-next": "^16.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",


### PR DESCRIPTION
Bumps Next.js family to **16.3.0** (latest, was `^16.2.10`) in `nextjs-starter`.

**Changes**
- `templates/nextjs-starter/template/package.json`: `next ^16.3.0`, `@next/eslint-plugin-next ^16.3.0`, `eslint-config-next ^16.3.0`

**Validation (local `file://`, per `MAINTENANCE_TEMPLATES.md#9`)**
```bash
REPO=/abs/path/to/cna-templates
CI=true npx create-awesome-node-app@latest my-app \
  -t "file://$REPO?subdir=templates/nextjs-starter" --skip-install
cd my-app
npm install          # 0 vuln
npm run lint         # pass
npm run type-check   # pass
npm run build        # Next.js 16.3.0 Turbopack ✓ Compiled successfully (4.1s), static pages 5/5
```

**CI**
- Expects `L0` (validate), `L1` (`nextjs-starter` scaffold+install+lint+type-check+build) to pass. Other templates unaffected (one fix per PR).

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the starter template’s Next.js and ESLint packages to newer versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->