### PR TITLE
fix: remove orphan extension types and enforce type validation

### DIFF
--- a/scripts/validate-templates.js
+++ b/scripts/validate-templates.js
@@ -178,7 +178,7 @@ function validateTypes(data) {
     const extTypes = Array.isArray(extension.type) ? extension.type : [extension.type];
     extTypes.forEach(extType => {
       if (!templateTypes.has(extType)) {
-        warning(`Extension "${extension.slug}" has type "${extType}" that doesn't match any template type`);
+        error(`Extension "${extension.slug}" has type "${extType}" that doesn't match any template type`);
       }
     });
   });

--- a/templates.json
+++ b/templates.json
@@ -264,11 +264,9 @@
       "description": "Automate GitHub workflows with Actions, Dependabot, and templates for issues and pull requests.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/all-github-setup",
       "type": [
-        "sls",
         "react",
         "webextension-react",
         "monorepo",
-        "backend",
         "nestjs-backend",
         "nextjs",
         "nextjs-saas-ai"
@@ -308,11 +306,9 @@
       "description": "Improve code quality with pre-commit hooks using Husky and Lint Staged.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/all-husky-lint-staged",
       "type": [
-        "sls",
         "react",
         "webextension-react",
         "webdriverio",
-        "backend",
         "nestjs-backend",
         "nextjs",
         "nextjs-saas-ai"
@@ -350,12 +346,10 @@
       "description": "Set up a development container with Docker and VSCode for consistent environments.",
       "url": "https://github.com/Create-Node-App/cna-templates/tree/main/extensions/all-devcontainer",
       "type": [
-        "sls",
         "react",
         "webextension-react",
         "monorepo",
         "webdriverio",
-        "backend",
         "nestjs-backend",
         "nextjs",
         "nextjs-saas-ai"


### PR DESCRIPTION
Closes #280.

Removes `sls` and `backend` from the three extensions that declared those types without any matching template (`github-setup`, `husky-lint-staged`, `development-container`). The validator now treats an unmatched extension type as an error instead of a warning, so orphan types cannot silently return.

Verified: `node scripts/validate-templates.js` reports `✅ All validations passed!`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template validation now fails when an extension type does not match its template type, preventing invalid configurations from passing validation.
  * Removed unsupported applicability types from GitHub Setup, Husky + Lint Staged, and Development Container templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->